### PR TITLE
Change assets to point to Make Handbook directly.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,13 @@ Either way, please include a description of the purpose behind the change so tha
 
 Any edit should have at least one review from a hosting team member before being merged.
 
+## Assets in Pages
+
+Assets like images are not automatically imported into the handbook.
+Please include them in PRs within the `assets/` directory in the repo for tracking.
+
+If you are merging a PR with assets, please upload these to the [handbook's media library](https://make.wordpress.org/hosting/wp-admin/upload.php) before merge, and link to the uploaded media directly.
+
 ## Generating Manifest
 
 When a new page is added to the handbook, or if a page's title or path has been changed during a PR, re-generating the manifest manually is currently required so that it can be imported to the handbook.

--- a/performance.md
+++ b/performance.md
@@ -51,7 +51,7 @@ Full Page Caching stores the HTML output of a request, but all the CSS, JS, imag
 
 It's important to have the ability to expire caches when necessary to avoid serving visitors old data. When available, selective caching is preferred over purging the entire cache, to avoid the cost of WordPress regenerating every page for the site. Furthermore, it's good practice to exclude certain types of pages from your full page caching completely because they are different for each user. For example, if you have an online store, it's imperative that your cart, checkout and profile pages are completely dynamic. In general, it’s a good idea to exclude all logged in users from the cache because they are supposed to see personalized content. Another important aspect is the default caching period, which can be different for each website depending on how often data is changed.
 
-![](https://raw.githubusercontent.com/WordPress/hosting-handbook/master/assets/full-page-caching-response-example.png)
+![](https://make.wordpress.org/hosting/files/2018/08/full-page-caching-response-example.png)
 
 ### Object Cache
 
@@ -65,7 +65,7 @@ Support for a persistent object cache gives WordPress, plugins, and themes, a pl
 
 For these reasons, persistent object caching support is commonly offered with managed WordPress hosting.
 
-![](https://raw.githubusercontent.com/WordPress/hosting-handbook/master/assets/wordpress-object-caching-example.png)
+![](https://make.wordpress.org/hosting/files/2018/08/wordpress-object-caching-example.png)
 
 > Transients are inherently sped up by caching plugins, where normal Options are not. A memcached plugin, for example, would make WordPress store transient values in fast memory instead of in the database. For this reason, transients should be used to store any data that is expected to expire, or which can expire at any time. Transients should also never be assumed to be in the database, since they may not be stored there at all.
 


### PR DESCRIPTION
Links the existing images to the handbook and adds documentation about how to add media in the future.

See: https://meta.trac.wordpress.org/ticket/5247#comment:5