### PR TITLE
recommend ext/sodium instead of ext/libsodium

### DIFF
--- a/server-environment.md
+++ b/server-environment.md
@@ -50,7 +50,7 @@ WordPress core makes use of PHP extensions. If the preferred extension is missin
 *   json - Used for communications with other servers.
 *   mbstring - Used to properly handle UTF8 text.
 *   mysqli - Connects to MySQL for database interactions.
-*   libsodium - Validates Signatures and provides securely random bytes.
+*   sodium - Validates Signatures and provides securely random bytes.
 *   openssl - Permits SSL-based connections to other hosts.
 *   pcre - Increases performance of pattern matching in code searches.
 *   imagick - Provides better image quality for media uploads. See [WP\_Image\_Editor is incoming!](https://make.wordpress.org/core/2012/12/06/wp_image_editor-is-incoming/) for details. Smarter image resizing (for smaller images) and PDF thumbnail support, when Ghost Script is also available.


### PR DESCRIPTION
slack conversation: https://wordpress.slack.com/archives/C3D6T7F8Q/p1594925003328900

ext/sodium is available in PHP core as of PHP 7.2. As far as I can tell from https://github.com/WordPress/WordPress/commit/cb01bbf97b11c01a1dbe36e51cdb15b3eac99a0a, WordPress is expecting ext/sodium to be loaded and not ext/libsodium.

There could be some more nuance needed in this section to cover all the supported versions of PHP.