### PR TITLE
added info box

### DIFF
--- a/index.md
+++ b/index.md
@@ -19,4 +19,4 @@ The Hosting Team meets in the WordPress Slack, in the [#hosting-community](https
 The Hosting Team is represented by team reps [@amykamala](https://profiles.wordpress.org/amykamala/), [@mikeschroder](https://profiles.wordpress.org/mikeschroder/), and [@jadonn](https://profiles.wordpress.org/jadonn/).
 
 
-\[info\]If you’re interested in improving this handbook, check the [Github Handbook repo](https://github.com/WordPress/hosting-handbook/), or leave a message in the [#hosting-community](https://wordpress.slack.com/archives/hosting-community/) channel of the [official WordPress Slack](https://make.wordpress.org/chat/).\[/info\]
+\[info\]If you’re interested in improving this handbook, check the <a href="https://github.com/WordPress/hosting-handbook/">Github Handbook repo</a>, or leave a message in the <a href="https://wordpress.slack.com/archives/hosting-community/">#hosting-community channel</a> of the official <a href="https://make.wordpress.org/chat/">WordPress Slack</a>.\[/info\]

--- a/index.md
+++ b/index.md
@@ -19,4 +19,4 @@ The Hosting Team meets in the WordPress Slack, in the [#hosting-community](https
 The Hosting Team is represented by team reps [@amykamala](https://profiles.wordpress.org/amykamala/), [@mikeschroder](https://profiles.wordpress.org/mikeschroder/), and [@jadonn](https://profiles.wordpress.org/jadonn/).
 
 
-\[info\]If you’re interested in improving this handbook, check the <a href="https://github.com/WordPress/hosting-handbook/">Github Handbook repo</a>, or leave a message in the <a href="https://wordpress.slack.com/archives/hosting-community/">#hosting-community channel</a> of the official <a href="https://make.wordpress.org/chat/">WordPress Slack</a>.\[/info\]
+\[info\]If you’re interested in improving this handbook, check the [Github Handbook repo](https://github.com/WordPress/hosting-handbook/), or leave a message in the [#hosting-community channel](https://wordpress.slack.com/archives/hosting-community/) of the official [WordPress Slack](https://make.wordpress.org/chat/).\[/info\]


### PR DESCRIPTION
Currently the shortcode block needs to have links as a <a>-tag. Thats why we converted the current links in the content to <a>-tags