### PR TITLE
Adding "About the Hosting Team" section

### DIFF
--- a/index.md
+++ b/index.md
@@ -4,6 +4,12 @@ Welcome to the [WordPress Hosting Handbook](https://make.wordpress.org/hosting/h
 
 ## About the Hosting Team
 
+People in this team are closely related to the world of hosting. They work as system administrators, plugin developers etc., and are concerned about improving the relationship between WordPress and the hosting where they are hosted.
+
+Our goals are ranging wide, although we are primarily focused on publishing documentation about the best options and the best practices hosters can apply when it comes to hosting WordPress. We are also working to offer tools to help improve WordPress performance when new versions and different elements of its environment (such as PHP, the database or the web server) appear.
+
+If you want to know more, feel free to take a look at our Get Involved section.
+
 ### What is the WordPress Hosting Team?
 
 The [Hosting Team](https://make.wordpress.org/hosting/) works to improve the WordPress user experience across hosting environments through user collaboration and education.


### PR DESCRIPTION
Related to https://github.com/WordPress/hosting-handbook/issues/32.

I took @javiercasares description version and tried to rewrite it a bit to make it shorter and easier to read. Let me know what you think 🙏🏻