### PR TITLE
Separating Contributor and projects

### DIFF
--- a/bin/handbook-manifest.json
+++ b/bin/handbook-manifest.json
@@ -11,6 +11,12 @@
 		"markdown_source": "https:\/\/github.com\/wordpress\/hosting-handbook\/blob\/master\/get-involved.md",
 		"parent": null
 	},
+	"team-projects": {
+		"title": "Team Projects",
+		"slug": "team-projects",
+		"markdown_source": "https:\/\/github.com\/wordpress\/hosting-handbook\/blob\/master\/team-projects.md",
+		"parent": "get-involved"
+	},
 	"contributor-day": {
 		"title": "Contributor Day",
 		"slug": "contributor-day",

--- a/contributor-day.md
+++ b/contributor-day.md
@@ -1,4 +1,4 @@
-# Contributor Day / Projects to contribute
+# Contributor Day
 
 The Contributor Day is an event, usually parallel to a WordCamp, focused on contributing to the WordPress Community in any of its teams.
 
@@ -38,84 +38,7 @@ In order for your contributions on GitHub to appear on your WordPress profile, y
 
 The projects of the Hosting team can vary, in addition to being able to cross with those of other teams.
 
-Currently the list of projects to contribute is:
-
-- [WordPress Hosting Team Handbook](https://make.wordpress.org/hosting/handbook/), focused on documentation.
-- [Automated Hosting Tests](https://make.wordpress.org/hosting/test-results/), focused on PHP compatibility.
-- Advanced Admin Handbook, focused on documentation, in collaboration with the [Documentation Team](https://make.wordpress.org/docs/).
-
-### WordPress Hosting Team Handbook
-
-#### What
-
-The Handbook contains information about the Hosting Team, along with hosting recommendations for running WordPress.
-
-The recommendations were put together by the team and used as a basis for [Site Health recommendations](https://make.wordpress.org/support/handbook/appendix/troubleshooting-using-the-health-check/) in WordPress. They're meant both as a reference for folks learning to host WordPress, and a way to help WordPress and Hosts improve together.
-
-#### How
-
-The handbook is in the process of being audited and improved. You can see the progress and contribute [through Github](https://github.com/WordPress/hosting-handbook).
-
-The first thing you'll have to do is [visit the repository page](https://github.com/WordPress/hosting-handbook) where all the information is. It's best to [visit the Issues list](https://github.com/WordPress/hosting-handbook/issues), check if your proposal is already contemplated or pending, and if it isn't, [create a New issue](https://github.com/WordPress/hosting-handbook/issues/new).
-
-After you submit an issue, we can discuss together the suggested changes.
-
-Once a PR is submitted, it will require an approval process. By default, once it is submitted, it will require review and approval by two people from the Hosting team. In cases where there are PRs related to corrections or internal operational elements, created by someone from the Hosting Team, only one review will be required.
-
-#### Tools
-
-To work on this project yo will need:
-
-- A GitHub account
-- A text / Markdown editor
-
-#### Help
-
-If help is needed, please ask in the [#hosting](https://wordpress.slack.com/archives/hosting) channel or contact [@Crixu](https://profiles.wordpress.org/crixu/), [@JavierCasares](https://profiles.wordpress.org/javiercasares/).
-
-### Automated Hosting Tests
-
-#### What
-
-The [Runner repo](https://github.com/WordPress/phpunit-test-runner) _(PHPUnit test runner)_ contains the parts of the hosting tests that run on a host, and the [Reporter repo](https://github.com/WordPress/phpunit-test-reporter) _(PHPUnit test reporter)_ contains the plugin that runs on WordPress.org for receiving and displaying the tests.
-
-#### How
-
-You can propose improvements or solve those available in both the PHPUnit test runner ([issues](https://github.com/WordPress/phpunit-test-runner/issues)) and the PHPUnit test reporter ([issues](https://github.com/WordPress/phpunit-test-reporter/issues)).
-
-#### Tools
-
-To work on this project yo will need:
-
-- A GitHub account
-- A text / PHP editor
-
-#### Help
-
-If help is needed, please ask in the [#hosting](https://wordpress.slack.com/archives/hosting) channel or contact [@pfefferle](https://profiles.wordpress.org/pfefferle/).
-
-### Advanced Admin Handbook
-
-#### What
-
-This new documentation is proposed as advanced regarding what currently exists for end users ([UserHub / Support](https://wordpress.org/support/)), with the goal that the documentation for users is free of advanced technical material, and that the documentation for developers ([DevHub](https://developer.wordpress.org/)) is very differentiated between what is development, and what are advanced development or system configurations.
-
-#### How
-
-Although we are still in a first step, if you know of other WordPress content that could be in this Handbook, please [open an issue](https://github.com/WordPress/Documentation-Issue-Tracker/issues) and discuss it with the Documentation team. Please use the label ["advanced administration"](https://github.com/WordPress/Documentation-Issue-Tracker/labels/advanced%20administration).
-
-If you want to help launch the Handbook as soon as possible, [please take an issue and work on it](https://github.com/zzap/WordPress-Advanced-administration-handbook/issues). You can comment on the site itself if you have any questions, suggestions or improvements.
-
-#### Tools
-
-To work on this project yo will need:
-
-- A GitHub account
-- A text / Markdown editor
-
-#### Help
-
-If help is needed, please ask in the [#docs](https://wordpress.slack.com/archives/docs), [#hosting](https://wordpress.slack.com/archives/hosting) channel or contact [@JavierCasares](https://profiles.wordpress.org/javiercasares/), [@lucp](https://profiles.wordpress.org/lucp/), [@milana_cap](https://profiles.wordpress.org/milana_cap/).
+Please, check our [Hosting Projects](https://make.wordpress.org/hosting/handbook/get-involved/team-projects/).
 
 ## Changelog
 

--- a/team-projects.md
+++ b/team-projects.md
@@ -1,0 +1,106 @@
+# Hosting Projects
+
+The projects of the Hosting team can vary, in addition to being able to cross with those of other teams.
+
+Currently the list of projects to contribute is:
+
+- [WordPress Hosting Team Handbook](https://make.wordpress.org/hosting/handbook/), focused on documentation.
+- [Automated Hosting Tests](https://make.wordpress.org/hosting/test-results/), focused on PHP compatibility.
+- [Advanced Admin Handbook](https://developer.wordpress.org/advanced-administration/), focused on documentation, in collaboration with the [Documentation Team](https://make.wordpress.org/docs/).
+
+## WordPress Hosting Team Handbook
+
+### What
+
+The Handbook contains information about the Hosting Team, along with hosting recommendations for running WordPress.
+
+The recommendations were put together by the team and used as a basis for [Site Health recommendations](https://make.wordpress.org/support/handbook/appendix/troubleshooting-using-the-health-check/) in WordPress. They're meant both as a reference for folks learning to host WordPress, and a way to help WordPress and Hosts improve together.
+
+### Skills
+
+- Technical writing
+- Systems Administration
+
+_Those skills are not required, but help._
+
+### How
+
+The handbook is in the process of being audited and improved. You can see the progress and contribute [through Github](https://github.com/WordPress/hosting-handbook).
+
+The first thing you'll have to do is [visit the repository page](https://github.com/WordPress/hosting-handbook) where all the information is. It's best to [visit the Issues list](https://github.com/WordPress/hosting-handbook/issues), check if your proposal is already contemplated or pending, and if it isn't, [create a New issue](https://github.com/WordPress/hosting-handbook/issues/new).
+
+After you submit an issue, we can discuss together the suggested changes.
+
+Once a PR is submitted, it will require an approval process. By default, once it is submitted, it will require review and approval by two people from the Hosting team. In cases where there are PRs related to corrections or internal operational elements, created by someone from the Hosting Team, only one review will be required.
+
+### Tools
+
+To work on this project yo will need:
+
+- A GitHub account
+- A text / Markdown editor
+
+### Help
+
+If help is needed, please ask in the [#hosting](https://wordpress.slack.com/archives/hosting) channel or contact [@Crixu](https://profiles.wordpress.org/crixu/), [@JavierCasares](https://profiles.wordpress.org/javiercasares/).
+
+## Automated Hosting Tests
+
+### What
+
+The [Runner repo](https://github.com/WordPress/phpunit-test-runner) _(PHPUnit test runner)_ contains the parts of the hosting tests that run on a host, and the [Reporter repo](https://github.com/WordPress/phpunit-test-reporter) _(PHPUnit test reporter)_ contains the plugin that runs on WordPress.org for receiving and displaying the tests.
+
+### Skills
+
+- PHP coding
+- Systems Administration
+
+_Those skills are not required, but help._
+
+### How
+
+You can propose improvements or solve those available in both the PHPUnit test runner ([issues](https://github.com/WordPress/phpunit-test-runner/issues)) and the PHPUnit test reporter ([issues](https://github.com/WordPress/phpunit-test-reporter/issues)).
+
+### Tools
+
+To work on this project yo will need:
+
+- A GitHub account
+- A text / PHP editor
+
+### Help
+
+If help is needed, please ask in the [#hosting](https://wordpress.slack.com/archives/hosting) channel or contact [@pfefferle](https://profiles.wordpress.org/pfefferle/).
+
+## Advanced Admin Handbook
+
+### What
+
+This new documentation is proposed as advanced regarding what currently exists for end users ([UserHub / Support](https://wordpress.org/support/)), with the goal that the documentation for users is free of advanced technical material, and that the documentation for developers ([DevHub](https://developer.wordpress.org/)) is very differentiated between what is development, and what are advanced development or system configurations.
+
+### Skills
+
+- Technical writing
+
+_Those skills are not required, but help._
+
+### How
+
+Although we are still in a first step, if you know of other WordPress content that could be in this Handbook, please [open an issue](https://github.com/WordPress/Documentation-Issue-Tracker/issues) and discuss it with the Documentation team. Please use the label ["advanced administration"](https://github.com/WordPress/Documentation-Issue-Tracker/labels/advanced%20administration).
+
+If you want to help launch the Handbook as soon as possible, [please take an issue and work on it](https://github.com/zzap/WordPress-Advanced-administration-handbook/issues). You can comment on the site itself if you have any questions, suggestions or improvements.
+
+### Tools
+
+To work on this project yo will need:
+
+- A GitHub account
+- A text / Markdown editor
+
+### Help
+
+If help is needed, please ask in the [#docs](https://wordpress.slack.com/archives/docs), [#hosting](https://wordpress.slack.com/archives/hosting) channel or contact [@JavierCasares](https://profiles.wordpress.org/javiercasares/), [@lucp](https://profiles.wordpress.org/lucp/), [@milana_cap](https://profiles.wordpress.org/milana_cap/).
+
+## Changelog
+
+- 2023-09-07: First version, from the Contributor Day page.


### PR DESCRIPTION
New page for the Tam Projects, different from the Contributor Day / volunteers onboarding.