### PR TITLE
Team Reps 2024 update

### DIFF
--- a/team-reps.md
+++ b/team-reps.md
@@ -12,12 +12,10 @@ More Information about [Team Reps: the Title, Responsibilities...](https://make.
 
 ### Hosting Team Reps
 
-The Hosting Team (2023) is represented by:
+The Hosting Team (2024) is represented by:
 
-- [@amykamala](https://profiles.wordpress.org/amykamala/)
 - [@crixu](https://profiles.wordpress.org/crixu/)
 - [@javiercasares](https://profiles.wordpress.org/javiercasares/)
-- [@jessibelle](https://profiles.wordpress.org/jessibelle/)
 
 ### Hosting Project Leads
 


### PR DESCRIPTION
Changed Team Reps from 2023 to 2004, leaving only the new WordPress profiles.

Issue: Update the Team Reps
https://github.com/WordPress/hosting-handbook/issues/216