### PR TITLE
Added WP 6.8 to compatibility.md (Issue #301)

### DIFF
--- a/compatibility.md
+++ b/compatibility.md
@@ -10,6 +10,7 @@ This table shows the versions available (and security supported) at the time of 
 
 WordPress | PHP | MySQL | MariaDB | Launch date
 ---- | ---- | ---- | ---- | ----
+WordPress 6.8 | 8.1 - 8.4 | 8.0 / 8.4 / 9.1 | 10.5 - 10.6 / 10.11 / 11.4 - 11.5 | 2025-04-15
 WordPress 6.7 | 8.1 - 8.3 | 8.0 / 8.4 / 9.1 | 10.5 - 10.6 / 10.11 / 11.4 - 11.5 | 2024-11-12
 WordPress 6.6 | 8.1 - 8.3 | 8.0 / 8.2 - 8.4 | 10.5 - 10.6 / 10.11 / 11.1 - 11.2 / 11.4 | 2024-07-16
 WordPress 6.5 | 8.1 - 8.3 | 8.0 - 8.3 | 10.4 - 10.6 / 10.11 / 11.0 - 11.3 | 2024-04-02


### PR DESCRIPTION

Re: [Hosting Handbook Issue #301](https://github.com/WordPress/hosting-handbook/issues/301)

Added a WordPress 6.8 line to the Handbook Compatibility page pending the release of WP 6.8 on 4/15/25.

The info matches the compatibility details in the [WP 6.8 Hosting Recommendations post draft ](https://docs.google.com/document/d/19k93IPaSGqKCXz2uzY7p2oAIY-CenyeSSCoNfCYFXRc/edit?tab=t.0#heading=h.kzl3cnpr4c1w)

Note: [This PR](https://github.com/WordPress/hosting-handbook/pull/302) updates this same page and does not include a 6.8 line. One of the PRs will need to be rebased prior to merging, depending on which is merged first.