### PR TITLE
Added WP 6.8 to compat page changelog re: #304

### DIFF
--- a/compatibility.md
+++ b/compatibility.md
@@ -61,6 +61,7 @@ WordPress 2.0+ | 4.2+ | 3.23.23+ |
 
 ## Changelog
 
+- 2024-04-15: Updated to WordPress 6.8
 - 2024-10-27: Updated to WordPress 6.7
 - 2024-07-04: Updated to WordPress 6.6
 - 2024-04-05: Updated to WordPress 6.5


### PR DESCRIPTION
Updated the Handbook Compatibility page bottom changelog to reflect the addition of WP 6.8

Re: [GitHub Issue #304 ](https://github.com/WordPress/hosting-handbook/issues/304)