### PR TITLE
Update server-environment.md for WP 6.8, adjust grammar and language, re Issue 402

### DIFF
--- a/server-environment.md
+++ b/server-environment.md
@@ -19,20 +19,20 @@ All published posts on compatibility are available at:
 
 ## Web Server
 
-The web server is piece of software that accepts user web requests and serves them the appropriate result. There are many different web servers that run on different operation systems. Generally, if your web server supports and executes PHP files, it should be able to work with WordPress.
+A web server is piece of software that receives and accepts web requests from website visitor computers, then returns the appropriate web data back to the user. There are many different types of pieces of web server software that run on different operating systems. Generally, if your web server supports and executes PHP files, it should be able to work with WordPress.
 
-The two most popular ones that are recommended are:
+The two most common pieces of web server software, and the ones recommended for WordPress, are:
 
 - [Apache HTTPD](https://httpd.apache.org/) 2.4
-- [nginx](https://nginx.org/) 1.26
+- [nginx](https://nginx.org/) 1.26 & 1.27
 
-Others are used by hosting companies and developers and are known to work well too:
+Additional software used by web hosting companies and developers that are known to work well with WordPress are:
 
 - [Angie](https://angie.software/en/) 1.7
 - [LiteSpeed Web Server](https://www.litespeedtech.com/products/litespeed-web-server) 6.3 / 6.2 / 6.1 / 6.0 / 5.4
 - [OpenLiteSpeed](https://openlitespeed.org/) 1.8 / 1.7
 
-_Those are the latest versions at the time of writing this document, for WordPress 6.6. Always keep your web server up-to-date to ensure best performance!_
+_Those are the latest versions at the time of writing this document, for WordPress 6.8. Always keep your web server up-to-date to ensure best performance!_
 
 ## PHP
 

--- a/server-environment.md
+++ b/server-environment.md
@@ -400,6 +400,7 @@ If you have an older version, you can activate the `Site Health` section install
 
 ## Changelog
 
+- 2025-06-04: Added WP 6.8 section, adjusted language and grammar.
 - 2024-09-17: Added minimum version of curl and openssl for PHP 8.4 extension.
 - 2024-07-04: Up-to-date for WordPress 6.6 compatibility.
 - 2024-04-06: Up-to-date for WordPress 6.5 compatibility.

--- a/server-environment.md
+++ b/server-environment.md
@@ -1,17 +1,19 @@
 # Server Environment
 
-Although WordPress can work in almost any environment, even very minimal ones, it must be acknowledged that it does not work completely well in these. That's why here we are going to make some minimum recommendations of the environment in which it would work most effectively when considering that most WordPress websites use third party plugins and themes which commonly introduce additional server-level requirements.
+Although WordPress can work in almost any environment, some environments are more optimal for functionality and performance while others are less so. Below are a few minimum recommendations for server environment configurations within which WordPress operates most efficiently, with consideration for WordPress websites that use third party plugins and themes which commonly introduce additional server-level requirements.
 
 ## WordPress Environment recommendations
 
 Quick recommendations:
 
+- [WordPress 6.8 Server Compatibility](https://make.wordpress.org/hosting/2025/04/16/wordpress-6-8-server-compatibility/)
+- [WordPress 6.7 Server Compatibility](https://make.wordpress.org/hosting/2024/11/05/wordpress-6-7-server-compatibility/)
 - [WordPress 6.6 Server Compatibility](https://make.wordpress.org/hosting/2024/07/10/wordpress-6-6-server-compatibility/)
 - [WordPress 6.5 PHP Compatibility](https://make.wordpress.org/hosting/2024/04/05/wordpress-6-5-php-compatibility/)
 - [WordPress 6.4 PHP Compatibility](https://make.wordpress.org/hosting/2023/11/16/wordpress-6-4-php-compatibility/)
 - [WordPress 6.3 PHP Compatibility](https://make.wordpress.org/hosting/2023/10/11/wordpress-6-3-php-compatibility/)
 
-All the post published are available at:
+All published posts on compatibility are available at:
 
 - [Release Compatibility](https://make.wordpress.org/hosting/category/release-compatibility/)
 

--- a/server-environment.md
+++ b/server-environment.md
@@ -268,7 +268,7 @@ End of life PHP versions:
 
 ### PHP Extensions
 
-WordPress core makes use of various PHP extensions when they're available. If the preferred extension is missing WordPress will either have to do more work to do the task the module helps with or, in the worst case, will remove functionality. All the extensions are for installations with PHP >= 7.4.
+WordPress core makes use of various PHP extensions when they're available. If the preferred extension is missing, WordPress will either have to do more work to do the task the module helps with, or in the worst case, will remove functionality. All the extensions are for installations with PHP >= 7.4.
 
 The PHP extensions listed below are _required_ for a WordPress site to work.
 

--- a/server-environment.md
+++ b/server-environment.md
@@ -112,14 +112,14 @@ _What does 'compatible with exceptions' mean?_
 _What does "beta" mean?_
 
 - PHP 8.3
-  - Deprecation notices. A deprecation notice is not an error, but rather an indicator of where additional work is needed for compatibility before PHP 9.0. With a deprecation notice, the PHP code will continue to work and nothing is broken.
+  - Deprecation notices. A deprecation notice is not an error, but is an indicator that the code being cited in the notice will be changed in future php versions. With a deprecation notice, the PHP code will continue to work and nothing is broken.
   - [**#59231**: Prepare for PHP 8.3.](https://core.trac.wordpress.org/ticket/59231). _NOTE: Has a patch, but moved to WordPress 6.7._
   - [**#59232**: Introduce #[Override] attribute to mark overloaded methods](https://core.trac.wordpress.org/ticket/59232) This attribute helps prevent coding errors by making it clear when a method is overloaded. It also assists with refactoring, debugging, and catching potential breaking changes in the parent class. _NOTE: Has a patch, but moved to Future Release._
   - [**#59233**: Improve error handling for unserialize()](https://core.trac.wordpress.org/ticket/59233). `maybe_unserialize()` function could still be confronted by data with trailing bytes. _NOTE: Moved to Future Release._
   - [**#59654**: PHP 8.x: various compatibility fixes for WordPress 6.7](https://core.trac.wordpress.org/ticket/59654). This ticket acts as a central hub for smaller patches that fix specific PHP 8.x failures. It continues the work from previous releases, ensuring that WordPress maintains compatibility with newer PHP versions like PHP 8.0, 8.1, 8.2, and upcoming versions like PHP 8.3. _NOTE: Moved to WordPress 6.7._
 
 - PHP 8.4
-  - Deprecation notices. A deprecation notice is not an error, but rather an indicator of where additional work is needed for compatibility before PHP 9.0. With a deprecation notice, the PHP code will continue to work and nothing is broken.
+  - Deprecation notices. A deprecation notice is not an error, but is an indicator that the code being cited in the notice will be changed in future php versions. With a deprecation notice, the PHP code will continue to work and nothing is broken.
   - [**#62061**: Prepare for PHP 8.4.](https://core.trac.wordpress.org/ticket/62061). _NOTE: Has a patch._
 
 _Other related tickets_
@@ -155,7 +155,7 @@ There are rare occasions when the `strip_tags()` function is passed a null value
 _What does "beta" mean?_
 
 - PHP 8.3
-  - _Deprecation notices_. A deprecation notice is not an error, but rather an indicator of where additional work is needed for compatibility before PHP 9.0. With a deprecation notice, the PHP code will continue to work and nothing is broken.
+  - _Deprecation notices_. A deprecation notice is not an error, but is an indicator that the code being cited in the notice will be changed in future php versions. With a deprecation notice, the PHP code will continue to work and nothing is broken.
   - [_Improve error handling for `unserialize()`_](https://core.trac.wordpress.org/ticket/59233). `maybe_unserialize()` function could still be confronted by data with trailing bytes. NOTE: Moved to WordPress 6.7.
 
 #### WordPress 6.5
@@ -184,7 +184,7 @@ _What does 'compatible with exceptions' mean?_
 _What does "beta" mean?_
 
 - PHP 8.3
-	- Deprecation notices: A deprecation notice is not an error, but rather an indicator of where additional work is needed for compatibility before PHP 9.0. With a deprecation notice, the PHP code will continue to work and nothing is broken.
+	- Deprecation notices: A deprecation notice is not an error, but is an indicator that the code being cited in the notice will be changed in future php versions. With a deprecation notice, the PHP code will continue to work and nothing is broken.
 
 #### WordPress 6.4
 
@@ -211,7 +211,7 @@ _What does 'compatible with exceptions' mean?_
 _What does "beta" mean?_
 
 - PHP 8.3
-	- Deprecation notices: A deprecation notice is not an error, but rather an indicator of where additional work is needed for compatibility before PHP 9.0. With a deprecation notice, the PHP code will continue to work and nothing is broken.
+	- Deprecation notices: A deprecation notice is not an error, but is an indicator that the code being cited in the notice will be changed in future php versions. With a deprecation notice, the PHP code will continue to work and nothing is broken.
 
 #### WordPress 6.3
 
@@ -234,7 +234,7 @@ _What does 'compatible with exceptions' mean?_
 _What does "beta" mean?_
 
 - PHP 8.2
-	- Deprecation notices: A deprecation notice is not an error, but rather an indicator of where additional work is needed for compatibility before PHP 9.0. With a deprecation notice, the PHP code will continue to work and nothing is broken.
+	- Deprecation notices: A deprecation notice is not an error, but is an indicator that the code being cited in the notice will be changed in future php versions. With a deprecation notice, the PHP code will continue to work and nothing is broken.
 
 ### About PHP
 

--- a/server-environment.md
+++ b/server-environment.md
@@ -83,7 +83,7 @@ _What does “beta compatible” or "beta support" mean?_
 
 _IMPORTANT: WordPress 6.7 is **compatible with exceptions** with PHP 8.0, PHP 8.1, PHP 8.2, and **beta compatible** with PHP 8.3, and PHP 8.4._
 
-_What "compatible with exceptions" mean?_
+_What does 'compatible with exceptions' mean?_
 
 - PHP 8.0
   - [**#48689**: Filesystem WP_Filesystem_FTPext and WP_Filesystem_SSH2 when connect fails.](https://core.trac.wordpress.org/ticket/48689) An investigation is underway as to why on some occasions the access to the files returns some type of error. _NOTE: Has a patch._
@@ -109,7 +109,7 @@ _What "compatible with exceptions" mean?_
   - [**#61154**: Fix the 'attributes' dynamic property in WP_Block.](https://core.trac.wordpress.org/ticket/61154) Fixing the 'attributes' dynamic property in the `WP_Block` class. _NOTE: Has a patch, but moved to WordPress 6.8._
   - [**#61890**: Handle WP_Term dynamic properties for PHP 8.2](https://core.trac.wordpress.org/ticket/61890). Handling of dynamic properties in the `WP_Term` class to ensure compatibility. _NOTE: Has a patch, but moved to WordPress 6.8._
 
-_What "beta" mean?_
+_What does "beta" mean?_
 
 - PHP 8.3
   - Deprecation notices. A deprecation notice is not an error, but rather an indicator of where additional work is needed for compatibility before PHP 9.0. With a deprecation notice, the PHP code will continue to work and nothing is broken.
@@ -139,7 +139,7 @@ _Other related tickets_
 
 _IMPORTANT: WordPress 6.6 is **compatible with exceptions** with PHP 8.1, and PHP 8.2, and **beta compatible** with PHP 8.3._
 
-_What "compatible with exceptions" means?_
+_What does 'compatible with exceptions' mean?_
 
 - PHP 8.1
   - _Not all "passing null to non-nullable" issues have been found._ In PHP, you can tell a function exactly what type of information it should accept. If you tell a function to expect a certain type of information, and you give it nothing at all (null is like saying "nothing"), then PHP gets confused and gives an error. This problem happens when someone accidentally gives a function "nothing" when the function wasn't designed to handle "nothing".
@@ -152,7 +152,7 @@ There are rare occasions when the `strip_tags()` function is passed a null value
   - [_`utf8_{encode|decode}` deprecation_](https://core.trac.wordpress.org/ticket/55603) with pending decision on requiring a PHP extension. NOTE: Has a patch, but moved to WordPress 6.7.
   - [_Unknown dynamic properties'_](https://core.trac.wordpress.org/ticket/56034) deprecation. NOTE: Moved to WordPress 6.7.
 
-_What "beta" means?_
+_What does "beta" mean?_
 
 - PHP 8.3
   - _Deprecation notices_. A deprecation notice is not an error, but rather an indicator of where additional work is needed for compatibility before PHP 9.0. With a deprecation notice, the PHP code will continue to work and nothing is broken.
@@ -166,7 +166,7 @@ _What "beta" means?_
 
 _IMPORTANT: WordPress 6.5 is **compatible with exceptions** with PHP 8.0, PHP 8.1, and PHP 8.2, and **beta compatible** with PHP 8.3._
 
-_What "compatible with exceptions" means?_
+_What does 'compatible with exceptions' mean?_
 
 - PHP 8.0
 	- [Named parameters](https://core.trac.wordpress.org/ticket/59649). WordPress does not support named parameters.
@@ -181,7 +181,7 @@ _What "compatible with exceptions" means?_
 	- [utf8_{encode|decode} deprecation](https://core.trac.wordpress.org/ticket/55603) with pending decision on requiring a PHP extension.
 	- [Unknown dynamic properties](https://core.trac.wordpress.org/ticket/56034) deprecations.
 
-_What "beta" means?_
+_What does "beta" mean?_
 
 - PHP 8.3
 	- Deprecation notices: A deprecation notice is not an error, but rather an indicator of where additional work is needed for compatibility before PHP 9.0. With a deprecation notice, the PHP code will continue to work and nothing is broken.
@@ -193,7 +193,7 @@ _What "beta" means?_
 
 _IMPORTANT: WordPress 6.4 is **compatible with exceptions** with PHP 8.0, PHP 8.1, and PHP 8.2, and **beta compatible** with PHP 8.3._
 
-_What "compatible with exceptions" means?_
+_What does 'compatible with exceptions' mean?_
 
 - PHP 8.0
 	- [Named parameters](https://core.trac.wordpress.org/ticket/59649). WordPress does not support named parameters.
@@ -208,7 +208,7 @@ _What "compatible with exceptions" means?_
 	- [utf8_{encode|decode} deprecation](https://core.trac.wordpress.org/ticket/55603) with pending decision on requiring a PHP extension.
 	- [Unknown dynamic properties](https://core.trac.wordpress.org/ticket/56034) deprecations.
 
-_What "beta" means?_
+_What does "beta" mean?_
 
 - PHP 8.3
 	- Deprecation notices: A deprecation notice is not an error, but rather an indicator of where additional work is needed for compatibility before PHP 9.0. With a deprecation notice, the PHP code will continue to work and nothing is broken.
@@ -220,7 +220,7 @@ _What "beta" means?_
 
 _IMPORTANT: WordPress 6.3 is **compatible with exceptions** with PHP 8.0 and PHP 8.1, and **beta compatible** with PHP 8.2._
 
-_What "compatible with exceptions" means?_
+_What does 'compatible with exceptions' mean?_
 
 - PHP 8.0
 	- Named parameters. WordPress does not support named parameters.
@@ -231,7 +231,7 @@ _What "compatible with exceptions" means?_
 	- [Replace most strip_tags() with wp_strip_tags()](https://core.trac.wordpress.org/ticket/57579).
 	- [unregister_setting() for unknown setting](https://core.trac.wordpress.org/ticket/57674).
 
-_What "beta" means?_
+_What does "beta" mean?_
 
 - PHP 8.2
 	- Deprecation notices: A deprecation notice is not an error, but rather an indicator of where additional work is needed for compatibility before PHP 9.0. With a deprecation notice, the PHP code will continue to work and nothing is broken.

--- a/server-environment.md
+++ b/server-environment.md
@@ -38,9 +38,42 @@ _Those are the latest versions at the time of writing this document, for WordPre
 
 PHP is a programming language on which WordPress code is based. This language runs on the server and it is important to keep it up to date, both for security and functionality.
 
-WordPress supports many versions of PHP, some even obsolete ([PHP Compatibility and WordPress Versions](https://make.wordpress.org/core/handbook/references/php-compatibility-and-wordpress-versions/)), for hosting companies we recommend:
+WordPress supports many versions of PHP, some even obsolete ([See PHP Compatibility and WordPress Versions](https://make.wordpress.org/core/handbook/references/php-compatibility-and-wordpress-versions/)). For hosting companies, the following is recommended:
 
 ### WordPress versions
+
+Below are details on specific WordPress versions, PHP compatibility for that version and development tickets related to PHP compatibility at the time of release. Tickets related to PHP compatibility can be found at any time by [Searching WordPress Trac](https://core.trac.wordpress.org/query?status=accepted&status=assigned&status=closed&status=new&status=reopened&status=reviewing&keywords=~php&keywords=~php80&keywords=~php81&keywords=~php82&keywords=~php83&keywords=~php88&milestone=6.7&milestone=6.8&milestone=Future+Release&group=resolution&col=id&col=summary&col=owner&col=type&col=priority&col=component&col=version&order=priority).
+
+#### WordPress 6.8
+
+- [PHP 8.1](https://www.php.net/ChangeLog-8.php#PHP_8_1) (Security Support)
+- [PHP 8.2](https://www.php.net/ChangeLog-8.php#PHP_8_2) (Active Support)
+- [PHP 8.3](https://www.php.net/ChangeLog-8.php#PHP_8_3) (Active Support)
+- [PHP 8.4](https://www.php.net/ChangeLog-8.php#PHP_8_4) (Candidate Support)
+
+_IMPORTANT: WordPress 6.8 is **fully compatible** with PHP 7.2 (1), 7.3 (1), 7.4 (1), 8.0(1), 8.1, and 8.2 and **beta compatible** with PHP 8.3, and PHP 8.4._ _As of the WordPress 6.8 release in April 2025, the term 'compatible with exceptions' is no longer used._
+
+_What does “beta compatible” or "beta support" mean?_
+
+'Beta compatible' or 'beta support' means that WordPress Core is actively working towards full compatibility with that PHP version, but there may still be some issues that are in the process of being resolved. Below are tickets outlining known issues regarding beta support for PHP 8.3 and 8.4. More information on when a PHP version goes from [beta to fully supported](https://make.wordpress.org/core/2025/04/09/php-8-support-clarification/) is documented by the core team.
+
+- PHP 8.3
+  - When using a 'Beta Compatible' PHP version, Deprecation notices may be seen in error logs, wp-admin or on-page. A deprecation notice is not an error, but is an indicator that the code being cited in the notice will be changed in future PHP versions. With a deprecation notice, the PHP code will continue to work, and nothing is broken.
+  - [#59231: Prepare for PHP 8.3.](https://core.trac.wordpress.org/ticket/59231). _NOTE: Closed/Fixed_
+  - [#59232: Introduce #[Override] attribute to mark overloaded methods](https://core.trac.wordpress.org/ticket/59232) This attribute helps prevent coding errors by making it clear when a method is overloaded. It also assists with refactoring, debugging, and catching potential breaking changes in the parent class. _NOTE: Has a patch, but moved to Future Release._
+  - [#59233: Improve error handling for unserialize()](https://core.trac.wordpress.org/ticket/59233). maybe_unserialize() function could still be confronted by data with trailing bytes. _NOTE: Moved to Future Release._
+
+- PHP 8.4
+  - Deprecation notices.  A deprecation notice is not an error, but is an indicator that the code being cited in the notice will be changed in future PHP versions. With a deprecation notice, the PHP code will continue to work, and nothing is broken.
+  - [#62061: Prepare for PHP 8.4.](https://core.trac.wordpress.org/ticket/62061). _NOTE: Closed/Fixed_
+
+- Other PHP Related Tickets 
+  - [#51525: Add new functions apply_filters_single_type() and apply_filters_ref_array_single_type().](https://core.trac.wordpress.org/ticket/51525). _Note: Moved to Future Release._
+  - [#54183: Tests: decide on how to handle deprecations in PHPUnit](https://core.trac.wordpress.org/ticket/54183). _Note: Moved to Future Release._
+  - [#54537: Tests: Enable PHP version check once PHP 8.0 compatibility is achieved.](https://core.trac.wordpress.org/ticket/54537). _Note: Moved to Future Release._
+  - [#58874: Code Modernization: Consider using the null coalescing operator.](https://core.trac.wordpress.org/ticket/58874). _Note: Moved to Future Release._
+  - [#59234: Introduce a wp_json_decode() function, including validation when available](https://core.trac.wordpress.org/ticket/59234). _Note: This ticket has been closed and won’t be moving forward._
+
 
 #### WordPress 6.7
 


### PR DESCRIPTION

Related to: https://github.com/WordPress/Advanced-administration-handbook/issues/402

Major changes to server-environment page:

- Added WP 6.8 to WP Versions section
- Added additional paragraphs and edited existing paragraphs for better context and clarity
- Refined language and grammar in numerous parts of the page
- Updated sub-section headings in PHP section for more clarity
- Updated changelog

