### PR TITLE
Fix: Correct 'as risk' to 'at risk' in security.md

### DIFF
--- a/security.md
+++ b/security.md
@@ -12,7 +12,7 @@ Keeping any system, not just WordPress, secure is continuous work. Good security
 
 Security largely consists of reducing risk and planning for recovery. Most security plans focus on minimizing the risk of unauthorized access only, but risk can never be successfully reduced to zero. As long as there is some risk, you must plan for recovery so that if something were to happen, user sites are not completely lost and can be quickly restored to normal operation.
 
-Security is also about more than WordPress. It is also about making sure your hosting environment is secure and your personal online practices and behaviors keep you safe. Good security depends on the technology in use and the people using the technology. Obsolete or out-of-date technology can have bugs or vulnerabilities that can put your WordPress website at risk. People's bad online practices can also put your WordPress website as risk. It is important to make sure that not only do you keep the technology you use up-to-date and maintained but also that employees are using security best practices when using the Internet and when interacting with your hosting platform or customer WordPress sites.
+Security is also about more than WordPress. It is also about making sure your hosting environment is secure and your personal online practices and behaviors keep you safe. Good security depends on the technology in use and the people using the technology. Obsolete or out-of-date technology can have bugs or vulnerabilities that can put your WordPress website at risk. People's bad online practices can also put your WordPress website at risk. It is important to make sure that not only do you keep the technology you use up-to-date and maintained but also that employees are using security best practices when using the Internet and when interacting with your hosting platform or customer WordPress sites.
 
 ## Throttling Multiple Login Attempts
 
@@ -74,7 +74,7 @@ WordPress websites should be run as non-privileged users. If possible, separate 
 
 ### Core and Upload Write Permissions
 
-For automatic security updates to function, PHP must be able to overwrite WordPress' core files. If you do not handle automated updates at the infrastructure level, this is the recommended practice.
+For automatic security updates to function, PHP must be able to overwrite WordPress core files. If you do not handle automated updates at the infrastructure level, this is the recommended practice.
 
 Additionally, WordPress stores assets and user uploaded files in a special uploads directory located in `/wp-content/uploads`, by default, within the WordPress root. The uploads directory must be web-accessible in order for user content and uploaded assets to be loaded by a browser. PHP will also need to be able to write to the user's uploads folder for WordPress to handle uploading user content.
 


### PR DESCRIPTION
Fix typo in security.md

- Changed "as risk" to "at risk" in line 15 for proper grammar.
-  Delete extra single quote