### PR TITLE
Adding a first version of Monthly Team Updates

### DIFF
--- a/bin/handbook-manifest.json
+++ b/bin/handbook-manifest.json
@@ -41,6 +41,13 @@
     "parent": "get-involved",
     "order": 4
   },
+  "team-updates": {
+    "title": "Monthly Hosting Team Updates",
+    "slug": "team-updates",
+    "markdown_source": "https:\/\/github.com\/wordpress\/hosting-handbook\/blob\/main\/team-updates.md",
+    "parent": "get-involved",
+    "order": 5
+  },
   "server-environment": {
     "title": "Server Environment",
     "slug": "server-environment",

--- a/team-updates.md
+++ b/team-updates.md
@@ -6,27 +6,27 @@ The Hosting Team is publishing monthly updates to make.wordpress.org/hosting and
 
 As an example you can view the monthly update for [July 2025](https://wp.me/p8aY12-Bn7), which was the first one published.
 
+In order to publish those reports you need to have Administrator access to make.wordpress.org/hosting and Editor access to make.wordpress.org/updates.
+
 ## How to generate the reports
 
 ### Activity on Hosting Tests
 
-For the Hosting Tests we report the newly shared reports by hosts for that month. This data can be gathered from the WordPress Backend of make.wordpress.org/hosting. Best is to access the result page directly with a filter applied like https://make.wordpress.org/hosting/wp-admin/edit.php?s&post_status=all&post_type=result&action=-1&m=202507, with having the last number being the year and month you want to get results for. 
-While on this page you can see the total amount of all published "post" as number of all test results ever shared. 
+For Hosting Tests the team reports the newly shared reports by hosts for that month. This data can be gathered from the WordPress Backend of make.wordpress.org/hosting. The results page can be accessed directly https://make.wordpress.org/hosting/wp-admin/edit.php?s&post_status=all&post_type=result&action=-1&m=202507, with having the last number being the year and month you want to get results for. 
+While on this page you can see the total amount of all published "posts" as number of all test results ever shared. 
 
-Last but not least we need to get the number of Test Reporters and the recent active ones. The total amount of all bot users can be checked from the [WordPress Backend too](https://make.wordpress.org/hosting/wp-admin/users.php?role=test-reporter). The number of recent active reporters can be counted on https://make.wordpress.org/hosting/test-results/. 
+Last but not least the number of test reporters and recent activity can be retrieved from the [WordPress Backend too](https://make.wordpress.org/hosting/wp-admin/users.php?role=test-reporter). The number of recent active reporters can be counted on https://make.wordpress.org/hosting/test-results/. 
 
 
 ### GitHub Report
 
-Collecting the numbers of contributions from GitHub is semi-automated as GitHub already provides us with a nice report for the last month:
+We prepared a script that collects stats from GitHub through the API and outputs the table and the contributors. Right now the script is located in [this repo](https://github.com/Crixu/github-stats).
 
-- [Advanced Administration Handbook](https://github.com/WordPress/Advanced-administration-handbook/pulse/monthly)
-- [Hosting Handbook](https://github.com/WordPress/hosting-handbook/pulse/monthly)
-- [Hosting Test Runner](https://github.com/WordPress/phpunit-test-runner/pulse/monthly)
-- [Hosting Test Reporter](https://github.com/WordPress/phpunit-test-reporter/pulse/monthly)
-
-Those pages directly provide us with an overview of the opened and closed PRs and Issues as well as a contributor overview. We're mentioning very active users as the most active GitHub contributors at the end of the post. 
+Follow the readme, create your own .env file and run the script. Once it is finished it will output all the required stats in the `report` folder. 
 
 ## Publishing on make.wordpress.org
 
 Once the data is collected go ahead and copy the report of last month from the WordPress Backend. Update all the **data and dates** and ask the team for a review before publishing. 
+
+The Crosspost to `/updates` won't include the content of the post. In order to fix this you need to login to make.wordpress.org/updates and edit the post to add the content.
+

--- a/team-updates.md
+++ b/team-updates.md
@@ -1,0 +1,32 @@
+# Monthly Hosting Team Updates
+The Hosting Team is publishing monthly updates to make.wordpress.org/hosting and https://make.wordpress.org/updates/ with the team activtiy currently measured in:
+
+- Acitvity on the Hosting Tests
+- GitHub Activities on Hosting Team mantained Repos 
+
+As an example you can view the monthly update for [July 2025](https://wp.me/p8aY12-Bn7), which was the first one published.
+
+## How to generate the reports
+
+### Activity on Hosting Tests
+
+For the Hosting Tests we report the newly shared reports by hosts for that month. This data can be gathered from the WordPress Backend of make.wordpress.org/hosting. Best is to access the result page directly with a filter applied like https://make.wordpress.org/hosting/wp-admin/edit.php?s&post_status=all&post_type=result&action=-1&m=202507, with having the last number being the year and month you want to get results for. 
+While on this page you can see the total amount of all published "post" as number of all test results ever shared. 
+
+Last but not least we need to get the number of Test Reporters and the recent active ones. The total amount of all bot users can be checked from the [WordPress Backend too](https://make.wordpress.org/hosting/wp-admin/users.php?role=test-reporter). The number of recent active reporters can be counted on https://make.wordpress.org/hosting/test-results/. 
+
+
+### GitHub Report
+
+Collecting the numbers of contributions from GitHub is semi-automated as GitHub already provides us with a nice report for the last month:
+
+- [Advanced Administration Handbook](https://github.com/WordPress/Advanced-administration-handbook/pulse/monthly)
+- [Hosting Handbook](https://github.com/WordPress/hosting-handbook/pulse/monthly)
+- [Hosting Test Runner](https://github.com/WordPress/phpunit-test-runner/pulse/monthly)
+- [Hosting Test Reporter](https://github.com/WordPress/phpunit-test-reporter/pulse/monthly)
+
+Those pages directly provide us with an overview of the opened and closed PRs and Issues as well as a contributor overview. We're mentioning very active users as the most active GitHub contributors at the end of the post. 
+
+## Publishing on make.wordpress.org
+
+Once the data is collected go ahead and copy the report of last month from the WordPress Backend. Update all the **data and dates** and ask the team for a review before publishing. 


### PR DESCRIPTION
I went ahead and added a how to on the Monthly Hosting Team posts. 
This should act like a first draft and to have all the links handy.
Addressing issue #341 