### PR TITLE
Update Team Reps Page 

### DIFF
--- a/team-reps.md
+++ b/team-reps.md
@@ -21,11 +21,27 @@ The Hosting Team (2025) is represented by:
 
 The Documentation projects (Hosting Handbook, and Advanced Administration Handbook) are lead by:
 
-- _Defaults to team reps. The team collectively manages these projects_
+- _Defaults to team reps/admins. The team collectively manages these projects_
 
 The PHPUnit Test projects (PHPUnit Test Runner, and PHPUnit Test Report) are lead by:
 
-- _Defaults to team reps. The team collectively manages these projects_
+- _Defaults to team reps/admins. The team collectively manages these projects_
+
+### Hosting Team Admins
+
+- [@zunaid321](https://profiles.wordpress.org/zunaid321/) (Team Rep 2025 - present)
+- [@jessibelle](https://profiles.wordpress.org/jessibelle/) (Team Rep 2023)
+- [@crixu](https://profiles.wordpress.org/crixu/) (Team Rep 2021-present)
+- [@amykamala](https://profiles.wordpress.org/amykamala/) (Team Rep 2019-2023)
+- [@chaion07](https://profiles.wordpress.org/chaion07/) (Team admin since 2021)
+
+#### Past Hosting Team Reps and Admins
+
+- [@javiercasares](https://profiles.wordpress.org/javiercasares/) (Team Rep 2021 - 2024)
+- [@jadonn](https://profiles.wordpress.org/jadonn/) (Team Rep 2018 - 2022)
+- [@pfefferle](https://profiles.wordpress.org/pfefferle/)
+- [@kirasong](https://profiles.wordpress.org/kirasong/) (Started the team in 2017, Team Rep 2017 - 2021)
+- [@danielbachhuber](https://profiles.wordpress.org/danielbachhuber/) (Started the team in 2017)
 
 ## Hosting Team Organization
 

--- a/team-reps.md
+++ b/team-reps.md
@@ -49,7 +49,6 @@ The PHPUnit Test projects (PHPUnit Test Runner, and PHPUnit Test Report) are lea
 
 Within the extensive ecosystem of WordPress, different teams work together to ensure the platform's ongoing development and success. Each of these teams has at least one representative, often referred to as a 'Team Rep'. For the Hosting Team, the Team Rep plays a vital role.
 
-
 #### Role of the Hosting Team Rep
 
 A Team Rep, specifically from the Hosting team, acts as the voice and ambassador of the Hosting Team within the broader WordPress Community. Their tasks are multifaceted:

--- a/team-reps.md
+++ b/team-reps.md
@@ -21,18 +21,18 @@ The Hosting Team (2025) is represented by:
 
 The Documentation projects (Hosting Handbook, and Advanced Administration Handbook) are lead by:
 
-- [@javiercasares](https://profiles.wordpress.org/javiercasares/): Hosting Handbook, Advanced Administration Handbook
-- [@crixu](https://profiles.wordpress.org/crixu/): Hosting Handbook
+- _Defaults to team reps. The team collectively manages these projects_
 
 The PHPUnit Test projects (PHPUnit Test Runner, and PHPUnit Test Report) are lead by:
 
-- _nobody is leading those projects_
+- _Defaults to team reps. The team collectively manages these projects_
 
 ## Hosting Team Organization
 
 ### Team Reps
 
 Within the extensive ecosystem of WordPress, different teams work together to ensure the platform's ongoing development and success. Each of these teams has at least one representative, often referred to as a 'Team Rep'. For the Hosting Team, the Team Rep plays a vital role.
+
 
 #### Role of the Hosting Team Rep
 


### PR DESCRIPTION
Re: https://github.com/WordPress/hosting-handbook/issues/321

Updated project lead info. Added team admins and past team reps/admins 