### PR TITLE
Add note to teamreps.md GitHub Teams section

### DIFF
--- a/team-reps.md
+++ b/team-reps.md
@@ -132,6 +132,7 @@ A Project Lead is responsible for guiding and overseeing a specific project unde
   - Be on the [#wcus](https://wordpress.slack.com/archives/C087S65L2) Slack channel, _recommended_
 
 - **GitHub Teams**
+    _Note: Must be a member of the [GitHub WordPress Organization](https://github.com/orgs/WordPress/) to view._
   - [Hosting Team](https://github.com/orgs/WordPress/teams/hosting-team)
   - [Hosting Handbook Team](https://github.com/orgs/WordPress/teams/hosting-handbook-team)
   - [Hosting Documentation Team](https://github.com/orgs/WordPress/teams/hosting-documentation-team)


### PR DESCRIPTION
Re: https://github.com/WordPress/hosting-handbook/issues/355 

Added a note to the Team Reps page GitHub Teams section that the GitHub Teams are only visible to members of the organization.