### PR TITLE
Add detailed instructions for creating Hosting meeting notes (fixes #57)

### DIFF
--- a/get-involved.md
+++ b/get-involved.md
@@ -69,7 +69,7 @@ There's always a need for more folks to join! If you're interested in helping ou
 
    * In the WordPress admin, go to **Posts → All Posts**.
    * Find a recent “Hosting Team meeting summary” or “Hosting Meeting Notes” post.
-   * Use the “Duplicate”/“Copy to new draft” option (provided by the duplicator/duplicate-post plugin) to create a new draft from that post. This keeps the basic structure and headings for you.
+   * Use the “Duplicate”/“Copy to new draft” option to create a new draft from that post. This keeps the basic structure and headings for you.
 
 3. **Update the post details**
 


### PR DESCRIPTION
This PR adds detailed instructions to the “Meetings: Taking notes” section of the `get-involved.md` page, addressing the request made in issue #57.

## What has been added

- A clear step-by-step workflow for writing Hosting Team meeting notes:
  - Requesting access to the Make site
  - Starting from an existing meeting notes template
  - Updating the title, tags, and metadata
  - Writing structured notes based on the agenda
- A detailed checklist of what meeting notes should include (meeting context, agenda links, key discussion points, decisions, action items, links, and next meeting info)
- Guidance on tone and writing style
- Instructions for review and publishing the notes using “Pending review” status

## Why this change is needed
The Hosting Handbook did not previously include clear and complete instructions on how contributors can write and publish meeting notes.  
This improvement provides a consistent reference for new contributors and supports the request in issue #57 to document this workflow.

## Related Issue
Fixes #57