### PR TITLE
Add missing live.md to handbook manifest

### DIFF
--- a/bin/handbook-manifest.json
+++ b/bin/handbook-manifest.json
@@ -83,6 +83,13 @@
     "parent": null,
     "order": 6
   },
+  "live": {
+    "title": "WordPress Hosting Live",
+    "slug": "live",
+    "markdown_source": "https:\/\/github.com\/wordpress\/hosting-handbook\/blob\/main\/live.md",
+    "parent": null,
+    "order": 7
+  },
   "performance": {
     "title": "Performance",
     "slug": "performance",


### PR DESCRIPTION
## Description
Add missing [live.md](cci:7://file:///Users/noruzzamanrubel/Desktop/WPContribution/hosting-handbook/live.md:0:0-0:0) file to the handbook manifest.

The [live.md](cci:7://file:///Users/noruzzamanrubel/Desktop/WPContribution/hosting-handbook/live.md:0:0-0:0) file exists in the repository but was not included in [bin/handbook-manifest.json](cci:7://file:///Users/noruzzamanrubel/Desktop/WPContribution/hosting-handbook/bin/handbook-manifest.json:0:0-0:0), which means it wouldn't appear in the handbook navigation on make.wordpress.org/hosting.

## Changes
- Added `live` entry to [bin/handbook-manifest.json](cci:7://file:///Users/noruzzamanrubel/Desktop/WPContribution/hosting-handbook/bin/handbook-manifest.json:0:0-0:0) with order 7 (between learn-hosting and performance)