### PR TITLE
Improve OPcache performance guidance

### DIFF
--- a/performance.md
+++ b/performance.md
@@ -82,6 +82,7 @@ As with any cache, opcode caches can keep changes from taking effect until the c
 For production WordPress environments, OPcache should generally be enabled for web requests and sized for the site or hosting platform. Important [OPcache runtime configuration](https://www.php.net/manual/en/opcache.configuration.php) settings to review include:
 
 - `opcache.memory_consumption`, which controls the shared memory available to OPcache.
+- `opcache.interned_strings_buffer`, which controls the memory available for interned strings. WordPress and plugins can reuse many strings, so hosts may need to tune this above the PHP default for larger sites.
 - `opcache.max_accelerated_files`, which controls how many scripts can be cached.
 - `opcache.validate_timestamps` and `opcache.revalidate_freq`, which control how OPcache checks whether cached PHP files have changed.
 

--- a/performance.md
+++ b/performance.md
@@ -77,12 +77,12 @@ The web server must read, compile, and run each PHP script. An opcode cache stor
 
 As with any cache, opcode caches can keep changes from taking effect until the cache expires or is purged. With opcode cache specifically, this means older versions of the compiled PHP code will be loaded. When updating plugins, themes, or WordPress core, the appropriate files should be purged from the cache to avoid continuing to load the older versions.
 
-[OPcache](https://www.php.net/manual/en/book.opcache.php) is the opcode cache bundled with modern PHP versions. It improves PHP performance by storing precompiled script bytecode in shared memory, which reduces the need to load and parse the same PHP files on each request.
+[OPcache](https://www.php.net/manual/en/book.opcache.php) is a PHP extension, bundled with PHP 5.5.0 and later, that acts as a caching mechanism to boost PHP performance. Precompiled script bytecode, low level binary representations of code, are stored in memory, enabling PHP files to be fetched from memory instead of loading and parsing files on each request.
 
-For production WordPress environments, OPcache should generally be enabled for web requests and sized for the site or hosting platform. Important [OPcache runtime configuration](https://www.php.net/manual/en/opcache.configuration.php) settings to review include:
+For production WordPress environments, it's recommended that OPcache be enabled for web requests and sized for the site or hosting platform. Important [OPcache runtime configuration](https://www.php.net/manual/en/opcache.configuration.php) settings to review include:
 
 - `opcache.memory_consumption`, which controls the shared memory available to OPcache.
-- `opcache.interned_strings_buffer`, which controls the memory available for interned strings. WordPress and plugins can reuse many strings, so hosts may need to tune this above the PHP default for larger sites.
+- `opcache.interned_strings_buffer`, which controls the memory available for interned strings (distinct string values stored in memory). WordPress and plugins can reuse many strings, so hosts may need to tune this above their standard PHP default to accommodate larger sites.
 - `opcache.max_accelerated_files`, which controls how many scripts can be cached.
 - `opcache.validate_timestamps` and `opcache.revalidate_freq`, which control how OPcache checks whether cached PHP files have changed.
 

--- a/performance.md
+++ b/performance.md
@@ -77,6 +77,22 @@ The web server must read, compile, and run each PHP script. An opcode cache stor
 
 As with any cache, opcode caches can keep changes from taking effect until the cache expires or is purged. With opcode cache specifically, this means older versions of the compiled PHP code will be loaded. When updating plugins, themes, or WordPress core, the appropriate files should be purged from the cache to avoid continuing to load the older versions.
 
+[OPcache](https://www.php.net/manual/en/book.opcache.php) is the opcode cache bundled with modern PHP versions. It improves PHP performance by storing precompiled script bytecode in shared memory, which reduces the need to load and parse the same PHP files on each request.
+
+For production WordPress environments, OPcache should generally be enabled for web requests and sized for the site or hosting platform. Important [OPcache runtime configuration](https://www.php.net/manual/en/opcache.configuration.php) settings to review include:
+
+- `opcache.memory_consumption`, which controls the shared memory available to OPcache.
+- `opcache.max_accelerated_files`, which controls how many scripts can be cached.
+- `opcache.validate_timestamps` and `opcache.revalidate_freq`, which control how OPcache checks whether cached PHP files have changed.
+
+If `opcache.validate_timestamps` is disabled, file changes will not be picked up automatically. In that configuration, OPcache must be reset or specific scripts must be invalidated during deployment, or the web server/PHP process must be restarted, so updates to WordPress core, plugins, and themes do not continue serving older compiled code.
+
+During active development, a shorter revalidation interval can reduce confusion when code changes do not appear immediately. In production, a longer interval or manual invalidation can reduce filesystem checks, but it should be paired with a reliable deployment or update process that clears OPcache when files change.
+
+Hosts should also monitor OPcache usage over time. If the cache runs out of memory, reaches the configured script limit, or restarts frequently because of wasted memory, the site may lose some of the performance benefit and spend more time recompiling PHP files.
+
+On shared or multi-user hosting, review the [OpCache Security](security.md#opcache-security) guidance before enabling a shared OPcache configuration.
+
 ### Fragment Cache
 
 This caching method allows saving sections of otherwise non-cacheable dynamic website content. It can help especially for sites where the majority of the page is static, but has certain dynamic elements, like a shopping cart, or for membership sites.

--- a/server-environment.md
+++ b/server-environment.md
@@ -331,7 +331,7 @@ The PHP extensions listed below are _recommended_ to allow some WordPress cache 
 
 - [apcu](https://www.php.net/manual/en/book.apcu.php) – In-memory key-value store for PHP (former APC stripped of opcode caching).
 - [memcached](https://www.php.net/manual/en/book.memcached.php) (requires libmemcached >= 1.0.0) - memcached is a high-performance, distributed memory object caching system, generic in nature, but intended for use in speeding up dynamic web applications by alleviating database load.
-- [opcache](https://www.php.net/manual/en/book.opcache.php) - PHP can be configured to preload scripts into the opcache when the engine starts. 
+- [opcache](https://www.php.net/manual/en/book.opcache.php) - Stores precompiled PHP bytecode to reduce repeated script parsing and compilation. See [Opcode Cache](performance.md#opcode-cache) for performance guidance.
 - [redis](https://pecl.php.net/package/redis) - PHP extension for interfacing with Redis.
 
 


### PR DESCRIPTION
## What this changes

Expands the existing Opcode Cache guidance in the Performance page with practical OPcache notes for WordPress hosting environments.

This also updates the `opcache` entry on the Server Environment page so it describes bytecode caching and links back to the performance guidance.

## Why

OPcache is already mentioned in the handbook, but the current guidance is brief. This adds more actionable information about production use, timestamp validation, deployment invalidation, monitoring, and shared-hosting security considerations.

## Related issue

Fixes WordPress/hosting-handbook#293