### PR TITLE
Add repository security policy

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+## Supported scope
+
+The WordPress Hosting Handbook is a documentation repository. It does not ship WordPress core, plugins, themes, hosting software, or server packages.
+
+This policy covers security-sensitive issues in this repository's documentation and GitHub configuration. It does not define support for WordPress software versions, hosting stacks, plugins, themes, server packages, or hosting platforms.
+
+## Reporting vulnerabilities
+
+For WordPress core, plugins, themes, WordPress.org, or the wider WordPress ecosystem, follow the official [WordPress security reporting guidance](https://wordpress.org/about/security/). WordPress core vulnerabilities should be reported through the [WordPress HackerOne program](https://hackerone.com/wordpress).
+
+Do not report exploitable security vulnerabilities in public GitHub issues or pull requests.
+
+If the vulnerability is in a hosting platform, server package, or other third-party project, report it to that project or vendor through their security reporting process.
+
+## Documentation issues
+
+If you find an insecure, outdated, or unclear recommendation in the Hosting Handbook documentation, open a public issue in this repository:
+
+https://github.com/WordPress/hosting-handbook/issues
+
+Include the affected page, the specific recommendation, and any safer source or replacement guidance you are suggesting. Do not include exploit details or private vulnerability information in public issues.


### PR DESCRIPTION
## Summary
- Add a GitHub security policy for the Hosting Handbook repository
- Clarify that the repository is documentation-only and does not define software support scope
- Route WordPress ecosystem vulnerability reports through the official WordPress security guidance
- Keep documentation-only issues in public GitHub issues while warning against public exploit disclosure

Fixes #406