### PR TITLE
Move the hosting-owned Advanced Administration pages into the handbook

### DIFF
--- a/multisite/create-network.md
+++ b/multisite/create-network.md
@@ -1,0 +1,113 @@
+# Create A Network
+
+You have the ability to create a [network](https://wordpress.org/documentation/article/glossary/#network) of [sites](https://wordpress.org/documentation/article/glossary/#site) by using the [multisite](https://wordpress.org/documentation/article/glossary/#multisite) feature. This article contains instructions for creating a multisite network. It is advised to read the post "[Before you Create a Network](https://developer.wordpress.org/advanced-administration/multisite/prepare-network/)" first, as it contains important information about planning your network.
+
+A multisite network can be very similar to your own personal version of WordPress.com. End users of your network can create their own sites on demand, just like end users of WordPress.com can create blogs on demand. If you do not have any need to allow end users to create their own sites on demand, you can create a multisite network in which only you, the administrator, can add new sites.
+
+A multisite network is a collection of sites that all share the same WordPress installation core files. They can also share plugins and themes. The individual sites in the network are _virtual_ sites in the sense that they do not have their own directories on your server, although they do have separate directories for media uploads within the shared installation, and they do have separate tables in the database. **NOTE:** [Upgraded and can't find the Network Admin menu?](https://developer.wordpress.org/advanced-administration/multisite/administration/#network-admin-link-location).
+
+## Step 0: Before You Begin {#step-0-before-you-begin}
+
+Compared with a typical single WordPress installation a network installation has additional considerations. You must decide if you want to use subdomains or subfolders and how you want to manage them. Installing themes and plugins is different: for example, each individual site of a network can activate both, but install neither.
+
+This guide describes how to install manually WordPress Multisite in your current WordPress installation. There are also available [ready-to-run packages](https://codex.wordpress.org/User:Beltranrubo/BitNami_Multisite) from BitNami.
+
+**Please read [Before You Create A Network](https://developer.wordpress.org/advanced-administration/multisite/prepare-network/) in full before continuing.**
+
+## Step 1: Prepare Your WordPress {#step-1-prepare-your-wordpress}
+
+Your existing WordPress site will be updated when creating a network. Unless this is a fresh install and you have nothing to lose, please [backup your database and files](https://developer.wordpress.org/advanced-administration/security/backup/).
+
+Verify that [Pretty Permalinks](https://wordpress.org/documentation/article/using-permalinks/) work on your single WP instance.
+
+Also deactivate all active plugins. You can reactivate them again after the network is created.
+
+If you plan to [run WordPress out of its own directory](https://developer.wordpress.org/advanced-administration/server/wordpress-in-directory/), do that _before_ activating Multisite.
+
+## Step 2: Allow Multisite {#step-2-allow-multisite}
+
+To enable the Network Setup menu item, you must first define multisite in the [wp-config.php](https://developer.wordpress.org/advanced-administration/wordpress/wp-config/) file.
+
+Open up `wp-config.php` and add this line **above** where it says `/* That's all, stop editing! Happy publishing. */`. If it doesn't say that anywhere, then add the line somewhere above the first line that begins with `require` or `include`:
+
+```
+/* Multisite */
+define( 'WP_ALLOW_MULTISITE', true );
+```
+
+You will need to refresh your browser to continue.
+
+## Step 3: Installing a Network {#step-3-installing-a-network}
+
+The previous step enables the **Network Setup** item in your **Tools menu**. Use that menu item to go to the **Create a Network of WordPress Sites** screen.
+
+To see an example of the Create a Network of WordPress Sites screen, look at [Administration](https://wordpress.org/documentation/article/administration-screens/) > [Tools](https://wordpress.org/documentation/article/administration-screens/#tools-managing-your-blog) > [Network Setup](https://wordpress.org/documentation/article/tools-network-screen/). The screen does not look exactly the same in all circumstances. The example shown is for an installation on `localhost`, which restricts the options available.
+
+[![Create a Network of WordPress Sites page](https://i0.wp.com/wordpress.org/support/files/2018/11/network-create.png?fit=1024%2C743&ssl=1)](https://i0.wp.com/wordpress.org/support/files/2018/11/network-create.png?fit=1024%2C743&ssl=1)
+_Create a Network of WordPress Sites page_
+
+**Addresses of Sites in your Network**
+
+You are given the choice between sub-domains and sub-directories, except when [existing settings](https://developer.wordpress.org/advanced-administration/multisite/prepare-network/#wordpress-settings-requirements) restrict your choice.
+
+You must choose one or the other. You can reconfigure your network to use the other choice after installation, despite the advice on the screen, but reconfiguring it might not be easy.
+
+You only need wildcard DNS for on-demand domain-based sites, despite the advice that may be on the screen.
+
+Once more: See [Before You Create A Network](https://developer.wordpress.org/advanced-administration/multisite/prepare-network/).
+
+* **Sub-domains** — a domain-based network in which on-demand sites use subdomains
+* **Sub-directories** — a path-based network in which on-demand sites use paths
+
+**Network Details**
+
+These are filled in automatically, but you can make changes. `Server Address`: the domain of the URL you are using to access your WordPress installation. `Network Title`: the title of your network as a whole. `Network Admin E-mail`: your email address as super admin of the network as a whole.
+
+Double-check the details and press the **Install** button.
+
+**Note:** The installer may perform a check for wildcard subdomains when you have not configured them yet, or when you do not need them at all. Ignore the warning if it does not apply to your network. See the [Server Requirements](https://developer.wordpress.org/advanced-administration/multisite/prepare-network/#server-requirements) section in [Before You Create A Network](https://developer.wordpress.org/advanced-administration/multisite/prepare-network/) for information about wildcard subdomains.
+
+## Step 4: Enabling the Network {#step-4-enabling-the-network}
+
+To enable your network, follow the instructions on the Create a Network of WordPress Sites screen. The instructions that you see are customized for your installation. They might not be the same as the examples you see here.
+
+[![Populated settings when creating a network of sites](https://i0.wp.com/wordpress.org/support/files/2018/11/tools-network-created.png?fit=1024%2C742&ssl=1)](https://i0.wp.com/wordpress.org/support/files/2018/11/tools-network-created.png?fit=1024%2C742&ssl=1)
+_Populated settings when creating a network of sites_
+
+Back up your existing `wp-config.php` and `.htaccess` files, unless this is a fresh install and you have nothing to lose.
+
+There are two steps:
+
+1. Add the specified lines to your [wp-config.php](https://developer.wordpress.org/advanced-administration/wordpress/wp-config/) file The extra lines go just after where you added the line in [Step 1: Prepare Your WordPress](https://developer.wordpress.org/advanced-administration/multisite/create-network/#step-1-prepare-your-wordpress).
+2. Add the specified lines to your `.htaccess` file If you do not have a `.htaccess` file, then create it in the same directory as your `wp-config.php` file. If you _ALREADY_ have a `.htaccess` file, replace any existing WP lines with these new ones. In some cases you might also have to add Options FollowSymlinks at the start of the file.
+
+After completing these steps, log in again using the link provided. You might have to clear your browser's cache and cookies in order to log in.
+
+## Step 5: Network Admin Settings {#step-5-network-admin-settings}
+
+[![](https://i0.wp.com/wordpress.org/support/files/2018/11/network-admin-link.png?fit=383%2C184&ssl=1)](https://i0.wp.com/wordpress.org/support/files/2018/11/network-admin-link.png?fit=383%2C184&ssl=1)
+
+At the left of your WordPress toolbar, **My Sites** is now the second item. There, all your sites are listed, with handy fly-out menus, as well as a **Network Admin** menu item. Under **Network Admin** you can use the **Dashboard** item to go to the Network Dashboard screen.
+
+Go to the [Settings Screen](https://developer.wordpress.org/advanced-administration/multisite/admin/) to configure network options, and the [Sites Screen](https://developer.wordpress.org/advanced-administration/multisite/admin/#Sites) to manage your sites.
+
+For more information, see: [Network Admin](https://developer.wordpress.org/advanced-administration/multisite/admin/)
+
+[Upgraded and can't find the Network Admin menu?](https://developer.wordpress.org/advanced-administration/multisite/administration/#network-admin-link-location)
+
+## Step 6: Administration {#step-6-administration}
+
+There are some additional things you might need to know about advanced administration of the network, due to the additional complexity of a Multisite. Even if you're familiar with WordPress, the location and behavior of Multisite Network Administration can be confusing.
+
+Read [Multisite Network Administration](https://developer.wordpress.org/advanced-administration/multisite/administration/) for more information.
+
+For help troubleshooting:
+
+* [Debugging a WordPress Network](https://developer.wordpress.org/advanced-administration/debug/debug-network/)
+
+## Related Articles {#related-articles}
+
+* [Hosting WordPress](https://wordpress.org/documentation/article/hosting-wordpress/)
+* [Installing Multiple Blogs](https://developer.wordpress.org/advanced-administration/before-install/multiple-instances/)
+* [How to adapt my plugin to Multisite?](https://stackoverflow.com/questions/13960514/how-to-adapt-my-plugin-to-multisite/)
+

--- a/multisite/index.md
+++ b/multisite/index.md
@@ -1,0 +1,10 @@
+# WordPress Multisite / Network
+
+WordPress Multisite is a feature of WordPress that enables you to create several instances of WordPress managed within one installation. You need to have rewrites enabled to use multisite. Check the [server requirements](https://developer.wordpress.org/advanced-administration/multisite/prepare-network/#server-requirements) for details. 
+
+One can use a multisite for a variety of purposes. Multisite is, for example, used by business sites that share some resources, such as the theme or plugins, and have different content for their regions. 
+
+The content in a Multisite has its own unique tables in the database, only the user table is shared between the instances.
+
+You can create a multisite that works with subdirectories ("path-based") or use domains or subdomains ("domain-based"). For how to map the domains, see [WordPress Multisite Domain Mapping](https://developer.wordpress.org/advanced-administration/multisite/domain-mapping/)
+

--- a/security/hardening.md
+++ b/security/hardening.md
@@ -1,0 +1,387 @@
+# Hardening WordPress
+
+Security in WordPress is [taken very seriously](https://wordpress.org/about/security/), but as with any other system there are potential security issues that may arise if some basic security precautions aren't taken. This article will go through some common forms of vulnerabilities, and the things you can do to help keep your WordPress installation secure.
+
+This article is not the ultimate quick fix to your security concerns. If you have specific security concerns or doubts, you should discuss them with people whom you trust to have sufficient knowledge of computer security and WordPress.
+
+## What is Security? {#what-is-security}
+
+Fundamentally, security _is not_ about perfectly secure systems. Such a thing might well be impractical, or impossible to find and/or maintain. What security is though is risk reduction, not risk elimination. It's about employing all the appropriate controls available to you, within reason, that allow you to improve your overall posture reducing the odds of making yourself a target, subsequently getting hacked.
+
+**Website Hosts**
+
+Often, a good place to start when it comes to website security is your hosting environment. Today, there are a number of options available to you, and while hosts offer security to a certain level, it's important to understand where their responsibility ends and yours begins. Here is a good article explaining the complicated dynamic between [web hosts and the security of your website](https://perezbox.com/2014/11/how-hosts-manage-your-website-security/). A secure server protects the privacy, integrity, and availability of the resources under the server administrator's control.
+
+Qualities of a trusted web host might include:
+
+* Readily discusses your security concerns and which security features and processes they offer with their hosting.
+* Provides the most recent stable versions of all server software.
+* Provides reliable methods for backup and recovery.
+
+Decide which security you need on your server by determining the software and data that needs to be secured. The rest of this guide will help you with this.
+
+**Website Applications**
+
+It's easy to look at web hosts and pass the responsibility of security to them, but there is a tremendous amount of security that lies on the website owner as well. Web hosts are often responsible for the infrastructure on which your website sits, they are not responsible for the application you choose to install.
+
+To understand where and why this is important you must [understand how websites get hacked](https://blog.sucuri.net/2015/05/website-security-how-do-websites-get-hacked.html), Rarely is it attributed to the infrastructure, and most often attributed to the application itself (i.e., the environment you are responsible for).
+
+### Security Themes {#security-themes}
+
+Keep in mind some general ideas while considering security for each aspect of your system:
+
+**Limiting access**
+
+Making smart choices that reduce possible entry points available to a malicious person.
+
+**Containment**
+
+Your system should be configured to minimize the amount of damage that can be done in the event that it is compromised.
+
+**Preparation and knowledge**
+
+Keeping backups and knowing the state of your WordPress installation at regular intervals. Having a plan to backup and recover your installation in the case of catastrophe can help you get back online faster in the case of a problem.
+
+**Trusted Sources**
+
+Do not get plugins/themes from untrusted sources. Restrict yourself to the WordPress.org repository or well known companies. Trying to get plugins/themes from the outside [may lead to issues](https://blog.sucuri.net/2014/03/unmasking-free-premium-wordpress-plugins.html).
+
+### Vulnerabilities on Your Computer {#vulnerabilities-on-your-computer}
+
+Make sure the computers you use are free of spyware, malware, and virus infections. No amount of security in WordPress or on your web server will make the slightest difference if there is a keylogger on your computer.
+
+Always keep your operating system and the software on it, especially your web browser, up to date to protect you from security vulnerabilities. If you are browsing untrusted sites, we also recommend using tools like no-script (or disabling javascript/flash/java) in your browser.
+
+### Vulnerabilities in WordPress {#vulnerabilities-in-wordpress}
+
+Like many modern software packages, WordPress is updated regularly to address new security issues that may arise. Improving software security is always an ongoing concern, and to that end **you should always keep up to date with the latest version of WordPress**. Older versions of WordPress are not maintained with security updates.
+
+#### Updating WordPress {#updating-wordpress}
+
+Main article: [Updating WordPress](https://wordpress.org/documentation/article/updating-wordpress/).
+
+The latest version of WordPress is always available from the main WordPress website at https://wordpress.org. Official releases are not available from other sites — **never** download or install WordPress from any website other than https://wordpress.org.
+
+Since version 3.7, WordPress has featured automatic updates. Use this functionality to ease the process of keeping up to date. You can also use the WordPress Dashboard to keep informed about updates. Read the entry in the Dashboard or the WordPress Developer Blog to determine what steps you must take to update and remain secure.
+
+If a vulnerability is discovered in WordPress and a new version is released to address the issue, the information required to exploit the vulnerability is almost certainly in the public domain. This makes old versions more open to attack, and is one of the primary reasons you should always keep WordPress up to date.
+
+If you are an administrator in charge of more than one WordPress installation, consider using [Subversion](https://codex.wordpress.org/Installing/Updating_WordPress_with_Subversion) to make management easier.
+
+#### Reporting Security Issues {#reporting-security-issues}
+
+If you think you have found a security flaw in WordPress, you can help by reporting the issue. See the [Security FAQ](https://make.wordpress.org/core/handbook/testing/reporting-security-vulnerabilities/) for information on how to report security issues.
+
+If you think you have found a bug, report it. See [Submitting Bugs](https://make.wordpress.org/core/handbook/testing/reporting-bugs/) for how to do this. You might have uncovered a vulnerability, or a bug that could lead to one.
+
+### Web Server Vulnerabilities {#web-server-vulnerabilities}
+
+The web server running WordPress, and the software on it, can have vulnerabilities. Therefore, make sure you are running secure, stable versions of your web server and the software on it, or make sure you are using a trusted host that takes care of these things for you.
+
+If you're on a shared server (one that hosts other websites besides your own) and a website on the same server is compromised, your website can potentially be compromised too even if you follow everything in this guide. Be sure to ask your [web host](https://wordpress.org/documentation/article/glossary/#Hosting_provider) what security precautions they take.
+
+### Network Vulnerabilities {#network-vulnerabilities}
+
+The network on both ends — the WordPress server side and the client network side — should be trusted. That means updating firewall rules on your home router and being careful about what networks you work from. An Internet cafe where you are sending passwords over an unencrypted connection, wireless or otherwise, is **not** a trusted network.
+
+Your web host should be making sure that their network is not compromised by attackers, and you should do the same. Network vulnerabilities can allow passwords and other sensitive information to be intercepted.
+
+### Passwords {#passwords}
+
+Many potential vulnerabilities can be avoided with good security habits. A strong password is an important aspect of this.
+
+The goal with your password is to make it hard for other people to guess and hard for a [brute force attack](https://developer.wordpress.org/advanced-administration/security/brute-force/) to succeed. Many [automatic password generators](https://www.google.com/?q=password+generator) are available that can be used to create secure passwords.
+
+WordPress also features a password strength meter which is shown when changing your password in WordPress. Use this when changing your password to ensure its strength is adequate.
+
+Things to avoid when choosing a password:
+
+* Any permutation of your own real name, username, company name, or name of your website.
+* A word from a dictionary, in any language.
+* A short password.
+* Any numeric-only or alphabetic-only password (a mixture of both is best).
+
+A strong password is necessary not just to protect your blog content. A hacker who gains access to your administrator account is able to install malicious scripts that can potentially compromise your entire server.
+
+In addition to using a strong password, it's a good idea to enable [two-step authentication](https://developer.wordpress.org/advanced-administration/security/mfa/) as an additional security measure.
+
+### FTP {#ftp}
+
+When connecting to your server you should use SFTP encryption if your web host provides it. If you are unsure if your web host provides SFTP or not, just ask them.
+
+Using SFTP is the same as FTP, except your password and other data is encrypted as it is transmitted between your computer and your website. This means your password is never sent in the clear and cannot be intercepted by an attacker.
+
+### File Permissions {#file-permissions}
+
+Some neat features of WordPress come from allowing various files to be writable by the web server. However, allowing write access to your files is potentially dangerous, particularly in a shared hosting environment.
+
+It is best to lock down your file permissions as much as possible and to loosen those restrictions on the occasions that you need to allow write access, or to create specific folders with less restrictions for the purpose of doing things like uploading files.
+
+Here is one possible permission scheme.
+
+All files should be owned by your user account, and should be writable by you. Any file that needs write access from WordPress should be writable by the web server, if your hosting set up requires it, that may mean those files need to be group-owned by the user account used by the web server process.
+
+**`/`**
+
+The root WordPress directory: all files should be writable only by your user account, except `.htaccess` if you want WordPress to automatically generate rewrite rules for you.
+
+**`/wp-admin/`**
+
+The WordPress administration area: all files should be writable only by your user account.
+
+**`/wp-includes/`**
+
+The bulk of WordPress application logic: all files should be writable only by your user account.
+
+**`/wp-content/`**
+
+User-supplied content: intended to be writable by your user account and the web server process.
+
+Within `/wp-content/` you will find:
+
+**`/wp-content/themes/`**
+
+Theme files. If you want to use the built-in theme editor, all files need to be writable by the web server process. If you do not want to use the built-in theme editor, all files can be writable only by your user account.
+
+**`/wp-content/plugins/`**
+
+Plugin files: all files should be writable only by your user account.
+
+Other directories that may be present with `/wp-content/` should be documented by whichever plugin or theme requires them. Permissions may vary.
+
+#### Changing file permissions {#changing-file-permissions}
+
+If you have shell access to your server, you can change file permissions recursively with the following command:
+
+For Directories:
+
+```
+find /path/to/your/wordpress/install/ -type d -exec chmod 755 {} \;
+```
+
+For Files:
+
+```
+find /path/to/your/wordpress/install/ -type f -exec chmod 644 {} \;
+```
+
+#### Regarding Automatic Updates {#regarding-automatic-updates}
+
+When you tell WordPress to perform an automatic update, all file operations are performed as the user that owns the files, not as the web server's user. All files are set to 0644 and all directories are set to 0755, and writable by only the user and readable by everyone else, including the web server.
+
+### Database Security {#database-security}
+
+If you run multiple blogs on the same server, it is wise to consider keeping them in separate databases each managed by a different user. This is best accomplished when performing the initial [WordPress installation](https://developer.wordpress.org/advanced-administration/before-install/howto-install/). This is a containment strategy: if an intruder successfully cracks one WordPress installation, this makes it that much harder to alter your other blogs.
+
+If you administer MySQL yourself, ensure that you understand your MySQL configuration and that unneeded features (such as accepting remote TCP connections) are disabled. See [MySQL Security](https://dev.mysql.com/doc/refman/8.0/en/security.html) for more information.
+
+#### Restricting Database User Privileges {#restricting-database-user-privileges}
+
+For normal WordPress operations, such as posting blog posts, uploading media files, posting comments, creating new WordPress users and installing WordPress plugins, the MySQL database user only needs data read and data write privileges to the MySQL database; SELECT, INSERT, UPDATE and DELETE.
+
+Therefore any other database structure and administration privileges, such as DROP, ALTER and GRANT can be revoked. By revoking such privileges you are also improving the containment policies.
+
+**Note:** Some plugins, themes and major WordPress updates might require to make database structural changes, such as add new tables or change the schema. In such case, before installing the plugin or updating a software, you will need to temporarily allow the database user the required privileges.
+
+**WARNING:** Attempting updates without having these privileges can cause problems when database schema changes occur. Thus, it is **NOT** recommended to revoke these privileges. If you do feel the need to do this for security reasons, then please make sure that you have a solid backup plan in place first, with regular whole database backups which you have tested are valid and that can be easily restored. A failed database upgrade can usually be solved by restoring the database back to an old version, granting the proper permissions, and then letting WordPress try the database update again. Restoring the database will return it back to that old version and the WordPress administration screens will then detect the old version and allow you to run the necessary SQL commands on it. Most WordPress upgrades do not change the schema, but some do. Only major point upgrades (3.7 to 3.8, for example) will alter the schema. Minor upgrades (3.8 to 3.8.1) will generally not. Nevertheless, **keep a regular backup**.
+
+### Securing wp-admin {#securing-wp-admin}
+
+Adding server-side password protection (such as [BasicAuth](https://en.wikipedia.org/wiki/Basic_access_authentication)) to `/wp-admin/` adds a second layer of protection around your blog's admin area, the login screen, and your files. This forces an attacker or bot to attack this second layer of protection instead of your actual admin files. Many WordPress attacks are carried out autonomously by malicious software bots.
+
+Simply securing the `wp-admin/` directory might also break some WordPress functionality, such as the AJAX handler at `wp-admin/admin-ajax.php`. See the [Resources](https://developer.wordpress.org/advanced-administration/resources/) section for more documentation on how to password protect your `wp-admin/` directory properly.
+
+The most common attacks against a WordPress blog usually fall into two categories.
+
+1. Sending specially-crafted HTTP requests to your server with specific exploit payloads for specific vulnerabilities. These include old/outdated plugins and software.
+2. Attempting to gain access to your blog by using "brute-force" password guessing.
+
+The ultimate implementation of this "second layer" password protection is to require an HTTPS SSL encrypted connection for administration, so that all communication and sensitive data is encrypted. _See [Administration Over SSL](https://developer.wordpress.org/advanced-administration/security/https/)._
+
+### Securing wp-includes {#securing-wp-includes}
+
+A second layer of protection can be added where scripts are generally not intended to be accessed by any user. One way to do that is to block those scripts using mod_rewrite in the .htaccess file. **Note:** to ensure the code below is not overwritten by WordPress, place it outside the `# BEGIN WordPress` and `# END WordPress` tags in the .htaccess file. WordPress can overwrite anything between these tags.
+
+```
+# Block the include-only files.
+<IfModule mod_rewrite.c>
+RewriteEngine On
+RewriteBase /
+RewriteRule ^wp-admin/includes/ - [F,L]
+RewriteRule !^wp-includes/ - [S=3]
+RewriteRule ^wp-includes/[^/]+\.php$ - [F,L]
+RewriteRule ^wp-includes/js/tinymce/langs/.+\.php - [F,L]
+RewriteRule ^wp-includes/theme-compat/ - [F,L]
+</IfModule>
+# BEGIN WordPress
+```
+
+Note that this won't work well on Multisite, as `RewriteRule ^wp-includes/[^/]+\.php$ - [F,L]` would prevent the ms-files.php file from generating images. Omitting that line will allow the code to work, but offers less security.
+
+### Securing wp-config.php {#securing-wp-config-php}
+
+You can move the `wp-config.php` file to the directory above your WordPress install. This means for a site installed in the root of your webspace, you can store `wp-config.php` outside the web-root folder.
+
+**Note:** Some people assert that [moving wp-config.php has minimal security benefits](https://wordpress.stackexchange.com/questions/58391/is-moving-wp-config-outside-the-web-root-really-beneficial) and, if not done carefully, may actually introduce serious vulnerabilities. [Others disagree](https://wordpress.stackexchange.com/questions/58391/is-moving-wp-config-outside-the-web-root-really-beneficial/74972#74972).
+
+Note that `wp-config.php` can be stored ONE directory level above the WordPress (where wp-includes resides) installation. Also, make sure that only you (and the web server) can read this file (it generally means a 400 or 440 permission).
+
+If you use a server with .htaccess, you can put this in that file (at the very top) to deny access to anyone surfing for it:
+
+```
+<Files "wp-config.php">
+Require all denied
+</Files>
+```
+
+### Disable File Editing {#disable-file-editing}
+
+The WordPress Dashboard by default allows administrators to edit PHP files, such as plugin and theme files. This is often the first tool an attacker will use if able to login, since it allows code execution. WordPress has a constant to disable editing from Dashboard. Placing this line in wp-config.php is equivalent to removing the 'edit_themes', 'edit_plugins' and 'edit_files' capabilities of all users:
+
+```
+define( 'DISALLOW_FILE_EDIT', true );
+```
+
+This will not prevent an attacker from uploading malicious files to your site, but might stop some attacks.
+
+### Plugins {#plugins}
+
+First of all, make sure your plugins are always updated. Also, if you are not using a specific plugin, delete it from the system.
+
+#### Firewall {#firewall}
+
+There are many plugins and services that can act as a firewall for your website. Some of them work by modifying your .htaccess  
+file and restricting some access at the Apache level, before it is processed by WordPress. A good example is [iThemes Security](https://wordpress.org/plugins/better-wp-security/) or [All in One WP Security](https://wordpress.org/plugins/all-in-one-wp-security-and-firewall/). Some firewall plugins act at the WordPress level, like [WordFence](https://wordpress.org/plugins/wordfence/) and [Shield](https://wordpress.org/plugins/wp-simple-firewall/), and try to filter attacks as WordPress is loading, but before it is fully processed.
+
+Besides plugins, you can also install a WAF (web firewall) at your web server to filter content before it is processed by WordPress. The most popular open source WAF is ModSecurity.
+
+A website firewall can also be added as intermediary between the traffic from the internet and your hosting server. These services all function as reverse proxies, in which they accept the initial requests and reroute them to your server, stripping it of all malicious requests. They accomplish this by modifying your DNS records, via an A record or full DNS swap, allowing all traffic to pass through the new network first. This causes all traffic to be filtered by the firewall before reaching your site. A few companies offer such service, like [CloudFlare](https://www.cloudflare.com/), [Sucuri](https://sucuri.net/wordpress-security/) and [Incapsula](https://www.imperva.com/).
+
+Additionally, these third parties service providers function as Content Distribution Network (CDNs) by default, introducing performance optimization and global reach.
+
+#### Plugins that need write access {#plugins-that-need-write-access}
+
+If a plugin wants write access to your WordPress files and directories, please read the code to make sure it is legit or check with someone you trust. Possible places to check are the [Support Forums](https://wordpress.org/support/welcome/) and [IRC Channel](https://make.wordpress.org/support/handbook/appendix/other-support-locations/introduction-to-irc/).
+
+#### Code execution plugins {#code-execution-plugins}
+
+As we said, part of the goal of hardening WordPress is containing the damage done if there is a successful attack. Plugins which allow arbitrary PHP or other code to execute from entries in a database effectively magnify the possibility of damage in the event of a successful attack.
+
+A way to avoid using such a plugin is to use [custom page templates](https://wordpress.org/documentation/article/pages/#Creating_your_own_Page_Templates) that call the function. Part of the security this affords is active only when you [disallow file editing within WordPress](#File_Permissions).
+
+### Security through obscurity {#security-through-obscurity}
+
+[Security through obscurity](https://en.wikipedia.org/wiki/Security_through_obscurity) is generally an unsound primary strategy. However, there are areas in WordPress where obscuring information _might_ help with security:
+
+1. **Rename the administrative account:** When creating an administrative account, avoid easily guessed terms such as `admin` or `webmaster` as usernames because they are typically subject to attacks first. On an existing WordPress install you may rename the existing account in the MySQL command-line client with a command like:
+```
+UPDATE wp_users SET user_login = 'newuser' WHERE user_login = 'admin';
+```
+or by using a MySQL frontend like [phpMyAdmin](https://developer.wordpress.org/advanced-administration/upgrade/phpmyadmin/).
+2. **Change the table_prefix:** Many published WordPress-specific SQL-injection attacks make the assumption that the table_prefix is `wp_`, the default. Changing this can block at least some SQL injection attacks.
+
+### Data Backups {#data-backups}
+
+Back up your data regularly, including your MySQL databases. See the main article: [Backing Up Your Database](https://developer.wordpress.org/advanced-administration/security/backup/database/).
+
+Data integrity is critical for trusted backups. Encrypting the backup, keeping an independent record of MD5 hashes for each backup file, and/or placing backups on read-only media increases your confidence that your data has not been tampered with.
+
+A sound backup strategy could include keeping a set of regularly-timed snapshots of your entire WordPress installation (including WordPress core files and your database) in a trusted location. Imagine a site that makes weekly snapshots. Such a strategy means that if a site is compromised on May 1st but the compromise is not detected until May 12th, the site owner will have pre-compromise backups that can help in rebuilding the site and possibly even post-compromise backups which will aid in determining how the site was compromised.
+
+### Logging {#logging}
+
+Logs are your best friend when it comes to understanding what is happening with your website, especially if you're trying to perform forensics. Contrary to popular beliefs, logs allow you to see what was done and by who and when. Unfortunately the logs will not tell you who, username, logged in, but it will allow you to identify the IP and time and more importantly, the actions the attacker might have taken. You will be able to see any of these attacks via the logs – Cross Site Scripting (XSS), Remote File Inclusion (RFI), Local File Inclusion (LFI) and Directory Traversal attempts. You will also be able to see brute force attempts. There are various [examples and tutorials](https://blog.sucuri.net/2015/08/ask-sucuri-how-did-my-wordpress-website-get-hacked-a-tutorial.html) available to help guide you through the process of parsing and analyzing your raw logs.
+
+If you get more comfortable with your logs you'll be able to see things like, when the theme and plugin editors are being used, when someone updates your widgets and when posts and pages are added. All key elements when doing forensic work on your web server. The are a few WordPress Security plugins that assist you with this as well, like the [Sucuri Auditing tool](https://wordpress.org/plugins/sucuri-scanner/) or the [Audit Trail](https://wordpress.org/plugins/audit-trail/) plugin.
+
+There are two key open-source solutions you'll want on your web server from a security perspective, this is a layered approach to security.
+
+OSSEC can run on any NIX distribution and will also run on Windows. When configured correctly its very powerful. The idea is correlate and aggregate all the logs. You have to be sure to configure it to capture all access_logs and error_logs and if you have multiple websites on the server account for that. You'll also want to be sure to filter out the noise. By default you'll see a lot of noise and you'll want to configure it to be really effective.
+
+### Monitoring {#monitoring}
+
+Sometimes prevention is not enough and you may still be hacked. That's why intrusion detection/monitoring is very important. It will allow you to react faster, find out what happened and recover your site.
+
+#### Monitoring your logs {#monitoring-your-logs}
+
+If you are on a dedicated or virtual private server, in which you have the luxury of root access, you have the ability easily configure things so that you can see what's going on. [OSSEC](https://www.ossec.net/) easily facilitates this and here is a little write up that might help you out [OSSEC for Website Security – Part I](https://perezbox.com/2013/03/ossec-for-website-security-part-i/).
+
+#### Monitoring your files for changes {#monitoring-your-files-for-changes}
+
+When an attack happens, it always leave traces. Either on the logs or on the file system (new files, modified files, etc). If you are using [OSSEC](https://www.ossec.net/) for example, it will monitor your files and alert you when they change.
+
+##### Goals {#goals}
+
+The goals of file system tracking include:
+
+* Monitor changed and added files
+* Log changes and additions
+* Ability to revert granular changes
+* Automated alerts
+
+##### General approaches {#general-approaches}
+
+Administrators can monitor file system via general technologies such as:
+
+* System utilities
+* Revision control
+* OS/kernel level monitoring
+
+##### Specific tools {#specific-tools}
+
+Options for file system monitoring include:
+
+* [diff](https://en.wikipedia.org/wiki/Diff_utility) – build clean test copy of your site and compare against production
+* [Git](https://git-scm.com/) – source code management
+* [inotify](https://en.wikipedia.org/wiki/Inotify) – OS kernel level file monitoring service that can run commands on filesystem events
+* [Watcher](https://github.com/gregghz/Watcher/blob/master/jobs.yml) – Python inotify library
+* [OSSEC](https://www.ossec.net/) – Open Source Host-based Intrusion Detection System that performs log analysis, file integrity checking, policy monitoring, rootkit detection, real-time alerting and active response.
+
+##### Considerations {#considerations}
+
+When configuring a file based monitoring strategy, there are many considerations, including the following.
+
+###### Run the monitoring script/service as root
+
+This would make it hard for attackers to disable or modify your file system monitoring solution.
+
+###### Disable monitoring during scheduled maintenance/upgrades
+
+This would prevent unnecessary notifications when you are performing regular maintenance on the site.
+
+###### Monitor only executable filetypes
+
+It may be reasonably safe to monitor only executable file types, such as .php files, etc.. Filtering out non-executable files may reduce unnecessary log entries and alerts.
+
+###### Use strict file system permissions
+
+Read about securing file permissions and ownership. In general, avoid allowing _execute_ and _write_ permissions to the extent possible.
+
+#### Monitoring your web server externally {#monitoring-your-web-server-externally}
+
+If the attacker tries to deface your site or add malware, you can also detect these changes by using a web-based integrity monitor solution. This comes in many forms today, use your favorite search engine and look for Web Malware Detection and Remediation and you'll likely get a long list of service providers.
+
+### Official WordPress Resources {#resources}
+
+* [WordPress Security Whitepaper](https://wordpress.org/about/security/)
+* [Brute Force Attacks](https://developer.wordpress.org/advanced-administration/security/brute-force/)
+* [Security FAQ](https://make.wordpress.org/core/handbook/testing/reporting-security-vulnerabilities/)
+* [FAQ – My site was hacked](https://wordpress.org/documentation/article/faq-my-site-was-hacked/)
+
+### See Also {#see-also}
+
+* [Open Source Security Explained](https://snyk.io/series/open-source-security/) (Snyk)
+* [Is WordPress Safe?](https://patchstack.com/articles/is-wordpress-safe/) (Patchstack)
+* [Authentication and Authorization — Official documentation for Apache HTTP server 2.2](https://httpd.apache.org/docs/current/howto/auth.html)
+* [Security Controls](https://docs.nginx.com/nginx/admin-guide/security-controls/) and [Advanced Security documentation for NGINX](https://docs.nginx.com/nginx-management-suite/acm/how-to/policies/advanced-security/)
+* Gridpane's [WordPress Security Knowledgebase](https://gridpane.com/knowledgebase/security/) and [WordPress Security Step-by-Step](https://gridpane.com/knowledgebase/security-strategies-and-tools/)
+* [How WordPress Uses Authentication Cookies & Sessions: A Technical Deep-Dive](https://snicco.io/blog/how-wordpress-uses-authentication-cookies-and-sessions) (Snicco)
+* [How WordPress Uses Salts and Why You Should Not Rotate Them: A Technical Deep-Dive](https://snicco.io/blog/wordpress-salts) (Snicco)
+* [Session Management and Security](https://github.com/snicco/fortress/blob/beta/docs/modules/session/session-managment-and-security.md#session-management-and-security) (Snicco)
+* [Securing WordPress Information Security Guideline](https://cio.ubc.ca/information-security/policy-standards-and-resources/securing-wordpress) (The University of British Columbia’s OCIO)
+* [Security, From the Basics to Enterprise with Calvin Alkan, Kathy Zant, and Carl Alexander](https://openchannels.fm/security-from-the-basics-to-enterprise-with-calvin-alkan/) (Video)
+* [WordPress Security Cutting Through the BS](https://blog.sucuri.net/2012/08/wordpress-security-cutting-through-the-bs.html)
+* [e-Book: Locking Down WordPress](https://newcodepoet.files.wordpress.com/2012/07/lockingdownwordpress1-1.pdf)
+* [Brad Williams: Lock it Up (Video)](https://wordpress.tv/2010/01/23/brad-williams-security-boston10/)
+* [Security Plugins](https://wordpress.org/plugins/tags/security)
+

--- a/server/control-panel.md
+++ b/server/control-panel.md
@@ -1,0 +1,83 @@
+# Control Panels
+
+## WP Toolkit for cPanel & WHM and Plesk
+
+WP Toolkit is a single management interface that allows you to install, configure, and manage WordPress® easily. WP Toolkit can install, configure, and manage WordPress versions 4.9 or later.
+
+cPanel & WHM versions 102 and above install WP Toolkit by default. WP Toolkit is available in Plesk if the server administrator has installed the WP Toolkit extension.
+
+## cPanel & WHM
+
+This tutorial describes how to install WordPress in the cPanel & WHM control panel using WP Toolkit. For other options to install WordPress in cPanel & WHM, read cPanel's [How to Install WordPress with cPanel](https://docs.cpanel.net/knowledge-base/third-party/how-to-install-wordpress-with-cpanel/) documentation.
+
+To install WordPress via WP Toolkit, perform the following actions:
+
+1. Log in to the cPanel interface with the information provided by your hosting company.
+2. Select _WP Toolkit_ from the lefthand menu bar. The _WP Toolkit_ interface will appear.
+3. Click _Install WordPress_ to create a new WordPress installation.
+
+### Install WordPress
+
+In the _Install Wordpress_ interface, click _Install_ to use the default settings. Or provide the following optional information to customize your installation, then click _Install_:
+
+   * The installation directory. By default, the installation uses the account's `public_html` directory.
+   * The title for the website.
+   * The plugin or theme set.
+   * The language of the website.
+   * The version of WordPress to install. By default, the installation uses the current WordPress version.
+   * The WordPress Administrator username and password.
+   * The database name, table prefix, username and password.
+   * The automatic update settings for the WordPress software, plugins, and themes.
+
+Click _Install Plugins_ if you want to install plugins and themes, or click _No, thanks_ to optionally install them later.
+
+## Plesk
+
+This tutorial provides step-by-step examples of installing Plesk WP Toolkit using the Plesk Web Installer.
+ 
+### Using Web Installer
+
+Install Plesk using Web Installer please open your browser and go to [get.plesk.com](https://get.plesk.com/). For Plesk installation, it is required a fresh Linux server with access to the Internet. You can install Plesk on any supported Linux-based OS.
+
+![Image_1](https://user-images.githubusercontent.com/19301688/189542599-4fce4d63-8060-416e-9fdf-f21ae62c87e1.png)
+
+Provide your server's IP address or hostname, enter your root password, or just add a private key.
+ 
+* Accept the terms of End-User License Agreement and click Install button.
+* Relax and wait for some time to let the installation be finalized.
+* Click on the Login link. No worries about "secure connection warnings", just make an exception.
+
+### Installing WordPress
+
+![image_2](https://user-images.githubusercontent.com/19301688/189542665-78f52a1c-e92b-4d70-bb5d-899ac02cc57e.png)
+
+* For an express installation, click Install (Quick). The latest version of WordPress will be installed, and the default settings will be used. The new instance will be available via HTTPS if SSL/TLS support is enabled for the domain.
+* If you want to change the default installation settings, click Install (Custom). This enables you to set up the administrator user, select the desired WordPress version, specify the database name, select auto-update settings, and more.
+
+### Managing WordPress Instances
+
+Go to WordPress to see all your WordPress instances. WP Toolkit groups information about each instance in blocks we call cards.
+
+![image_3](https://user-images.githubusercontent.com/19301688/189542692-5d6f38b5-1b32-4de8-8f40-2abe9a5d1d86.png)
+
+A card shows a screenshot of your website and features several controls that give you easy access to frequently used tools. The screenshot changes in real time to reflect the changes you make to your website. For example, if you switch the maintenance mode on or change the WordPress theme, the screenshot of the website will change immediately.
+
+### Tools
+
+In the "Tools" section, click to access the following WP Toolkit features:
+
+![image_4](https://user-images.githubusercontent.com/19301688/189542713-abf476de-fcbd-4113-9975-1c2961765190.png)
+
+* "Sync" to synchronize the content of your website with another one.
+* "Clone" to make a full copy of your website.
+* "Manage Files" to manage the website's files in File Manager.
+* "Back Up/Restore" to create a backup of your website and restore it if necessary.
+
+The controls below give you easy access to the following settings and tools:
+
+* "Search engine indexing" shows your website in search results of search engines.
+* "Caching (nginx)" speeds up the website load time and reduces server load.
+* "Debugging" helps you debug a website that is not ready for viewing and being tested or developed.
+* "Maintenance mode" hides your website's content from visitors.
+* "Password Protection" specifies the password you will use to log in to WordPress from Plesk.
+

--- a/server/file-permissions.md
+++ b/server/file-permissions.md
@@ -1,0 +1,310 @@
+# Changing File Permissions
+
+On computer file systems, different files and directories have **permissions** that specify who and what can read, write, modify and access them. This is important because WordPress may need access to write to files in your `wp-content` directory to enable certain functions.
+
+## Short explanation
+
+Linux [file permissions](https://en.wikipedia.org/wiki/File_system_permissions) consist primarily of three components -- the permissions the owner of the file or folder has, the permissions members of the group that owns the file or folder have, and the permissions that anyone else has for accessing or modifying the file and folder. The three permission components are usually represented using three numbers in order of the owner's permission level, the group's permission level, and everyone's permission level. _There is technically a fourth component, but that is beyond what we need to know to secure WordPress. It will not be discussed here._
+
+There are three kinds of access each for the user, the group, and everyone else. They are read access, write access, and execute access. Read access lets you read the contents of the file or the directory. Write access lets you modify the file or the directory. And execute access lets you run the file like a program or a script.
+
+## Permission Modes
+
+```
+ 7      5      5
+user   group  world
+r+w+x  r+x    r+x
+4+2+1  4+0+1  4+0+1  = 755
+```
+
+The permission mode is computed by adding up the following values for the user, the file group, and for everyone else. The diagram shows how.
+
+* **R**ead 4 – Allowed to read files
+* **W**rite 2 – Allowed to write/modify files
+* e**X**ecute1 – Read/write/delete/modify/directory
+
+```
+ 7      4      4
+user   group  world
+r+w+x  r      r
+4+2+1  4+0+0  4+0+0  = 744
+```
+
+### Example Permission Modes
+
+| Mode | Str Perms | Explanation |
+| ---- | --------- | ----------- |
+| **0677** | -rw-rwxrwx | owner has rw only(6), other and group has rwx (7) |
+| **0670** | -rw-rwx— | owner has rw only, group has rwx, others have no permission |
+| **0666** | -rw-rw-rw- | all have rw only (6) |
+| **0607** | -rw—-rwx | owner has rw only, group has no permission and others have rwx |
+| **0600** | -rw——- | owner has rw only, group and others have no permission |
+| **0477** | -r–rwxrwx | owner has read only (4), other and group has rwx (7) |
+| **0470** | -r–rwx— | owner has read only, group has rwx, others have no permission |
+| **0407** | -r—–rwx | owner has read only, other has rwx, group has no permission |
+| **0444** | -r–r–r– | all have read only (4) |
+| **0400** | -r——– | owner has read only(4), group and others have no permission(0) |
+
+## Permission Scheme for WordPress
+
+Permissions will be different from host to host, so this guide only details general principles. It cannot cover all cases. This guide applies to servers running a standard setup (note, for shared hosting using "suexec" methods, see below).
+
+Typically, all files should be owned by your user (ftp) account on your web server, and should be writable by that account. On shared hosts, files should never be owned by the webserver process itself (sometimes this is **www**, or **apache**, or **nobody** user).
+
+Any file that needs write access from WordPress should be owned or group-owned by the user account used by WordPress (which may be different than the server account). For example, you may have a user account that lets you FTP files back and forth to your server, but your server itself may run using a separate user, in a separate usergroup, such as **dhapache** or **nobody**. If WordPress is running as the FTP account, that account needs to have write access, i.e., be the owner of the files, or belong to a group that has write access. In the latter case, that would mean permissions are set more permissively than default (for example, 775 rather than 755 for folders, and 664 instead of 644).
+
+The file and folder permissions of WordPress should be the same for most users, depending on the type of installation you performed and the umask settings of your system environment at the time of install.
+
+**NOTE:** If an experienced user installed WordPress for you, you likely do not need to modify file permissions. Unless you are experiencing problems with permission errors, or you _want to_, you probably should not mess with this.
+
+**NOTE:** If you installed WordPress yourself, you likely DO need to modify file permissions. Some files and directories should be "hardened" with stricter permissions, specifically, the wp-config.php file. This file is initially created with 644 permissions, and it's a hazard to leave it like that. See Security and Hardening.
+
+Typically, all core WordPress files should be writable only by your user account (or the httpd account, if different). (Sometimes though, multiple ftp accounts are used to manage an install, and if all ftp users are known and trusted, i.e., not a shared host, then assigning group writable may be appropriate. Ask your server admin for more info.) However, if you utilize mod_rewrite Permalinks or other `.htaccess` features you should make sure that WordPress can also write to your `/.htaccess` file.
+
+If you want to use the built-in theme editor, all files need to be group writable. Try using it before modifying file permissions, it should work. (This may be true if different users uploaded the WordPress package and the Plugin or Theme. This wouldn't be a problem for Plugin and Themes installed via the admin. When uploading files with different ftp users group writable is needed. On shared hosting, make sure the group is exclusive to users you trust... the apache user shouldn't be in the group and shouldn't own files.)
+
+Some plugins require the `/wp-content/` folder be made writeable, but in such cases they will let you know during installation. In some cases, this may require assigning 755 permissions. The same is true for `/wp-content/cache/` and maybe `/wp-content/uploads/` (if you're using [MultiSite](https://developer.wordpress.org/advanced-administration/multisite/create-network/) you may also need to do this for `/wp-content/blogs.dir/`)
+
+Additional directories under /wp-content/ should be documented by whatever plugin / theme requires them. Permissions will vary.
+
+```
+|
+|- index.php
+|- wp-admin
+|   |- wp-admin.css
+|- wp-blog-header.php
+|- wp-comments-post.php
+|- wp-commentsrss2.php
+|- wp-config.php
+|- wp-content
+|   |- cache
+|   |- plugins
+|   |- themes
+|   |- uploads
+|- wp-cron.php
+|- wp-includes
+|- xmlrpc.php
+```
+
+### Shared Hosting with suexec
+
+The above may not apply to shared hosting systems that use the "suexec" approach for running PHP binaries. This is a popular approach used by many web hosts. For these systems, the php process runs as the owner of the php files themselves, allowing for a simpler configuration and a more secure environment for the specific case of shared hosting.
+
+Note: suexec methods should NEVER be used on a single-site server configuration, they are more secure **only** for the specific case of shared hosting.
+
+In such an suexec configuration, the correct permissions scheme is simple to understand.
+
+* All files should be owned by the actual user's account, not the user account used for the httpd process.
+* Group ownership is irrelevant, unless there's specific group requirements for the web-server process permissions checking. This is not usually the case.
+* All directories should be 755 or 750.
+* All files should be 644 or 640. Exception: wp-config.php should be 440 or 400 to prevent other users on the server from reading it.
+* No directories should ever be given 777, even upload directories. Since the php process is running as the owner of the files, it gets the owners permissions and can write to even a 755 directory.
+
+In this specific type setup, WordPress will detect that it can directly create files with the proper ownership, and so it will not ask for FTP credentials when upgrading or installing plugins.
+
+Popular methods used by sysadmins for this setup are:
+
+* [suPHP](https://smarsching.github.io/suphp/Home.html), runs through php-cgi, currently unmaintained since 2013.
+* [mod_ruid2](https://github.com/mind04/mod-ruid2), apache module, currently unmaintained since 2013.
+* [mpm-itk](http://mpm-itk.sesse.net/), apache module.
+* [mod_fcgid](https://httpd.apache.org/mod_fcgid/), an Apache module and FastCGI server with more extensive configuration.
+* [PHP-FPM](https://php-fpm.org/), an alternative FastCGI server with shared OPCode, for use with Apache and Nginx.
+
+## Using an FTP Client
+
+[FTP programs](https://developer.wordpress.org/advanced-administration/upgrade/ftp/) ("clients") allow you to set permissions for files and directories on your remote host. This function is often called `chmod` or `set permissions` in the program menu.
+
+In [WordPress install](https://developer.wordpress.org/advanced-administration/before-install/howto-install/), two files that you will probably want to alter are the index page, and the css which controls the layout. Here's how you change index.php – _the process is the same for any file_.
+
+In the screenshot below, look at the last column – that shows the permissions. It looks a bit confusing, but for now just note the sequence of letters.  
+
+[![](https://wordpress.org/documentation/files/2019/02/podz_filezilla_12.gif)](https://wordpress.org/documentation/files/2019/02/podz_filezilla_12.gif)
+Initial permissions
+
+Right-click 'index.php' and select 'File Permissions'
+A popup screen will appear.
+
+[![](https://wordpress.org/documentation/files/2019/02/podz_filezilla_13.gif)](https://wordpress.org/documentation/files/2019/02/podz_filezilla_13.gif)
+Altering file permissions
+
+Don't worry about the check boxes. Just delete the 'Numeric value:' and enter the number you need – in this case it's 666. Then click OK.  
+
+[![](https://wordpress.org/documentation/files/2019/02/podz_filezilla_14.gif)](https://wordpress.org/documentation/files/2019/02/podz_filezilla_14.gif)
+Permissions have been altered.
+
+You can now see that the file permissions have been changed.
+
+### Unhide the hidden files
+
+By default, most [FTP Clients](https://developer.wordpress.org/advanced-administration/upgrade/ftp/), including [FileZilla](https://sourceforge.net/projects/filezilla/), keep hidden files, those files beginning with a period (.), from being displayed. But, at some point, you may need to see your hidden files so that you can change the permissions on that file. For example, you may need to make your [.htaccess](https://wordpress.org/documentation/article/glossary#htaccess) file, the file that controls [permalinks](https://wordpress.org/documentation/article/using-permalinks/), writeable.
+
+To display hidden files in FileZilla, in it is necessary to select 'View' from the top menu, then select 'Show hidden files'. The screen display of files will refresh and any previously hidden file should come into view.
+
+To get FileZilla to always show hidden files – under Edit, Settings, Remote File List, check the Always show hidden files box.
+
+In the latest version of Filezilla, the 'Show hidden files' option was moved to the 'Server' tab. Select 'Force show hidden files.'
+
+## Using the Command Line
+
+If you have shell/SSH access to your hosting account, you can use `chmod` to change file permissions, which is the preferred method for experienced users. Before you start using `chmod` it would be recommended to read some tutorials to make sure you understand what you can achieve with it. Setting incorrect permissions can take your site offline, so please take your time.
+
+* [Unix Permissions](https://web.archive.org/web/20190715230319/http://www.washington.edu/computing/unix/permissions.html)
+
+You can make **all** the files in your `wp-content` directory writable in two steps, but before making every single file and folder writable you should first try safer alternatives like modifying just the directory. Try each of these commands first and if they don't work then go recursive, which will make even your themes image files writable. Replace **DIR** with the folder you want to write in
+
+```
+chmod -v 746 DIR
+chmod -v 747 DIR
+chmod -v 756 DIR
+chmod -v 757 DIR
+chmod -v 764 DIR
+chmod -v 765 DIR
+chmod -v 766 DIR
+chmod -v 767 DIR
+```
+
+If those fail to allow you to write, try them all again in order, except this time replace -v with -R, which will recursively change each file located in the folder. If after that you still can't write, you may now try 777.
+
+### [About Chmod](#about-chmod)
+
+`chmod` is a unix command that means "**ch**ange **mod**e" on a file. The `-R` flag means to apply the change to every file and directory inside of `wp-content`. 766 is the mode we are changing the directory to, it means that the directory is readable and writable by WordPress and any and all other users on your system. Finally, we have the name of the directory we are going to modify, `wp-content`. If 766 doesn't work, you can try 777, which makes all files and folders readable, writable, and executable by all users, groups, and processes.
+
+If you use [Permalinks](https://wordpress.org/documentation/article/using-permalinks/) you should also change permissions of .htaccess to make sure that WordPress can update it when you change settings such as adding a new page, redirect, category, etc.. which requires updating the .htaccess file when mod_rewrite Permalinks are being used.
+
+1. Go to the main directory of WordPress
+2. Enter `chmod -v 666 .htaccess`
+
+**NOTE:** From a security standpoint, even a small amount of protection is preferable to a world-writeable directory. Start with low permissive settings like 744, working your way up until it works. Only use 777 if necessary, and hopefully only for a temporary amount of time.
+
+## The dangers of 777
+
+The crux of this permission issue is how your server is configured. The username you use to FTP or SSH into your server is most likely not the username used by the server application itself to serve pages.
+
+```
+ 7      7      7
+user   group  world
+r+w+x  r+w+x  r+w+x
+4+2+1  4+2+1  4+2+1  = 777
+```
+
+Often the Apache server is 'owned' by the **www-data**, **dhapache** or **nobody** user accounts. These accounts have a limited amount of access to files on the server, for a very good reason. By setting your personal files and folders owned by your user account to be World-Writable, you are literally making them World Writable. Now the www-data, dhapache and nobody users that run your server, serving pages, executing php interpreters, etc. will have full access to your user account files.
+
+This provides an avenue for someone to gain access to your files by hijacking basically any process on your server, this also includes any other users on your machine. So you should think carefully about modifying permissions on your machine. I've never come across anything that needed more than 767, so when you see 777 ask why it's necessary.
+
+### The Worst Outcome
+
+The worst that can happen as a result of using 777 permissions on a folder or even a file, is that if a malicious cracker or entity is able to upload a devious file or modify a current file to execute code, they will have complete control over your blog, including having your database information and password.
+
+### Find a Workaround
+
+It is usually pretty easy to have the enhanced features provided by the impressive WordPress plugins available, without having to put yourself at risk. Contact the Plugin author or your server support and request a workaround.
+
+## Finding Secure File Permissions
+
+The .htaccess file is one of the files that is accessed by the owner of the process running the server. So if you set the permissions too low, then your server won't be able to access the file and will cause an error. Therein lies the method to find the most secure settings. Start too restrictive and increase the permissions until it works.
+
+### Example Permission Settings
+
+The following example has a _custom compiled php-cgi binary_ and a _custom php.ini_ file located in the cgi-bin directory for executing php scripts. To prevent the interpreter and `php.ini` file from being accessed directly in a web browser they are protected with a .htaccess file.
+
+Default Permissions (umask 022)
+
+```
+644 -rw-r--r--  /home/user/wp-config.php
+644 -rw-r--r--  /home/user/cgi-bin/.htaccess
+644 -rw-r--r--  /home/user/cgi-bin/php.ini
+755 -rwxr-xr-x  /home/user/cgi-bin/php.cgi
+755 -rwxr-xr-x  /home/user/cgi-bin/php5.cgi
+```
+
+Secured Permissions
+
+```
+600 -rw-------  /home/user/wp-config.php
+6**0**4 -rw----r--  /home/user/cgi-bin/.htaccess
+6**00** -rw-------  /home/user/cgi-bin/php.ini
+7**11** -rwx--x--x  /home/user/cgi-bin/php.cgi
+**100** ---x------  /home/user/cgi-bin/php5.cgi
+```
+
+#### .htaccess permissions
+
+**644 > 604** – The bit allowing the group owner of the .htaccess file read permission was removed. 644 is normally required and recommended for .htaccess files.
+
+#### php.ini permissions
+
+**644 > 600** – Previously all groups and all users with access to the server could access the php.ini, even by just requesting it from the site. The tricky thing is that because the php.ini file is only used by the php.cgi, we only needed to make sure the php.cgi process had access. The php.cgi runs as the same user that owns both files, so that single user is now the only user able to access this file.
+
+#### php.cgi permissions
+
+**755 > 711** This file is a compiled php-cgi binary used instead of mod_php or the default vanilla php provided by the hosting company. The default permissions for this file are 755.
+
+#### php5.cgi permissions
+
+**755 > 100** – Because of the setup where the user account is the owner of the process running the php cgi, no other user or group needs access, so we disable all access except execution access. This is interesting because it really works. You can try reading the file, writing to the file, etc. but the only access you have to this file is to run php scripts. And as the owner of the file you can always change the permission modes back again.
+
+```
+$ cat: php5.cgi: Permission denied
+./php5.cgi:  Welcome
+```
+
+## SELinux
+
+[Security Enhanced linux](https://en.wikipedia.org/wiki/Security-Enhanced_Linux) is a kernel security module that provides mechanisms by which processes can be sandboxed into particular contexts. This is of particular use to limit the actions that web pages can perform on other parts of the operating system. Actions that are denied by the security policy are often hard to distinguish from regular file permission errors.
+
+selinux is typically installed on Redhat family distributions (e.g., CentOS, Fedora, Scientific, Amazon and others).
+
+### How to determine if selinux is the problem?
+
+If you are on a debian based distribution, you are probably fine.
+
+Run the following command (on rpm based systems);
+
+```
+$ rpm -qa | grep selinux
+selinux-policy-targeted-3.13.1-166.el7_4.7.noarch
+selinux-policy-3.13.1-166.el7_4.7.noarch
+libselinux-2.5-11.el7.x86_64
+libselinux-python-2.5-11.el7.x86_64
+libselinux-utils-2.5-11.el7.x86_64
+```
+
+and to check whether it is the cause of denials of permissions:
+
+```
+$ getenforce
+Enforcing
+```
+
+One issue that selinux causes is blocking the wp-admin tools from writing out the \`.htaccess\` file that is required for url rewriting. There are several commands for inspecting this behaviour
+
+```
+$ audit2allow -w -a
+type=AVC msg=audit(1517275570.388:55362): avc:  denied  { write } for  pid=11831 comm="httpd" path="/var/www/example.org/.htaccess" dev="vda1" ino=67137959 scontext=system_u:system_r:httpd_t:s0 tcontext=system_u:object_r:httpd_sys_content_t:s0 tclass=file
+        Was caused by:
+        The boolean httpd_unified was set incorrectly.
+        Description:
+        Allow httpd to unified
+
+        Allow access by executing:
+        # setsebool -P httpd_unified 1
+```
+and
+
+```
+$ ausearch -m avc -c httpd
+----
+time->Tue Jan 30 01:30:31 2018
+type=PROCTITLE msg=audit(1517275831.762:55364): proctitle=2F7573722F7362696E2F6874747064002D44464F524547524F554E44
+type=SYSCALL msg=audit(1517275831.762:55364): arch=c000003e syscall=21 success=no exit=-13 a0=55b9c795d268 a1=2 a2=0 a3=1 items=0 ppid=11826 pid=11829 auid=4294967295 uid=48 gid=48 euid=48 suid=48 fsuid=48 egid=48 sgid=48 fsgid=48 tty=(none) ses=4294967295 comm="httpd" exe="/usr/sbin/httpd" subj=system_u:system_r:httpd_t:s0 key=(null)
+type=AVC msg=audit(1517275831.762:55364): avc:  denied  { write } for  pid=11829 comm="httpd" name="bioactivator.org" dev="vda1" ino=67137958 scontext=system_u:system_r:httpd_t:s0 tcontext=unconfined_u:object_r:httpd_sys_content_t:s0 tclass=dir
+----
+```
+  
+You can temporarily disable selinux to determine if it is the cause of the problems;
+
+```
+$ setenforce
+usage:  setenforce \[ Enforcing | Permissive | 1 | 0 \]
+```
+

--- a/server/httpd.md
+++ b/server/httpd.md
@@ -1,0 +1,363 @@
+# Apache HTTPD / .htaccess
+
+## .htaccess
+
+The `.htaccess` is a distributed configuration file, and is how Apache handles configuration changes on a per-directory basis.
+
+WordPress uses this file to manipulate how Apache serves files from its root directory, and subdirectories thereof. Most notably, WP modifies this file to be able to handle pretty permalinks.
+
+This page may be used to restore a corrupted `.htaccess` file (e.g. a misbehaving plugin).
+
+### Basic WP
+
+```
+# BEGIN WordPress
+
+RewriteEngine On
+RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+RewriteBase /
+RewriteRule ^index\.php$ - [L]
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteRule . /index.php [L]
+
+# END WordPress
+```
+
+### Multisite
+
+#### WordPress 3.5 and up
+
+If you activated Multisite on WordPress 3.5 or later, use one of these.
+
+##### WordPress >=3.5 Subfolder Example
+
+```
+# BEGIN WordPress Multisite
+# Using subfolder network type: https://wordpress.org/documentation/article/htaccess/#multisite
+
+RewriteEngine On
+RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+RewriteBase /
+RewriteRule ^index\.php$ - [L]
+
+# add a trailing slash to /wp-admin
+RewriteRule ^([_0-9a-zA-Z-]+/)?wp-admin$ $1wp-admin/ [R=301,L]
+
+RewriteCond %{REQUEST_FILENAME} -f [OR]
+RewriteCond %{REQUEST_FILENAME} -d
+RewriteRule ^ - [L]
+RewriteRule ^([_0-9a-zA-Z-]+/)?(wp-(content|admin|includes).*) $2 [L]
+RewriteRule ^([_0-9a-zA-Z-]+/)?(.*\.php)$ $2 [L]
+RewriteRule . index.php [L]
+
+# END WordPress Multisite
+```
+
+##### WordPress >=3.5 SubDomain Example
+
+```
+# BEGIN WordPress Multisite
+# Using subdomain network type: https://wordpress.org/documentation/article/htaccess/#multisite
+
+RewriteEngine On
+RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+RewriteBase /
+RewriteRule ^index\.php$ - [L]
+
+# add a trailing slash to /wp-admin
+RewriteRule ^wp-admin$ wp-admin/ [R=301,L]
+
+RewriteCond %{REQUEST_FILENAME} -f [OR]
+RewriteCond %{REQUEST_FILENAME} -d
+RewriteRule ^ - [L]
+RewriteRule ^(wp-(content|admin|includes).*) $1 [L]
+RewriteRule ^(.*\.php)$ $1 [L]
+RewriteRule . index.php [L]
+
+# END WordPress Multisite
+```
+
+#### WordPress 3.4 and below
+
+If you originally installed WordPress with 3.4 or older and activated Multisite then, you need to use one of these:
+
+##### WordPress <=3.4 SubFolder Example
+
+WordPress 3.0 through 3.4.2
+
+```
+# BEGIN WordPress Multisite
+# Using subfolder network type: https://wordpress.org/documentation/article/htaccess/#multisite
+
+RewriteEngine On
+RewriteBase /
+RewriteRule ^index\.php$ - [L]
+
+# uploaded files
+RewriteRule ^([_0-9a-zA-Z-]+/)?files/(.+) wp-includes/ms-files.php?file=$2 [L]
+
+# add a trailing slash to /wp-admin
+RewriteRule ^([_0-9a-zA-Z-]+/)?wp-admin$ $1wp-admin/ [R=301,L]
+
+RewriteCond %{REQUEST_FILENAME} -f [OR]
+RewriteCond %{REQUEST_FILENAME} -d
+RewriteRule ^ - [L]
+RewriteRule ^[_0-9a-zA-Z-]+/(wp-(content|admin|includes).*) $1 [L]
+RewriteRule ^[_0-9a-zA-Z-]+/(.*\.php)$ $1 [L]
+RewriteRule . index.php [L]
+
+# END WordPress Multisite
+```
+
+##### WordPress <=3.4 SubDomain Example
+
+```
+# BEGIN WordPress Multisite
+# Using subdomain network type: https://wordpress.org/documentation/article/htaccess/#multisite
+
+RewriteEngine On
+RewriteBase /
+RewriteRule ^index\.php$ - [L]
+
+# uploaded files
+RewriteRule ^files/(.+) wp-includes/ms-files.php?file=$1 [L]
+
+RewriteCond %{REQUEST_FILENAME} -f [OR]
+RewriteCond %{REQUEST_FILENAME} -d
+RewriteRule ^ - [L]
+RewriteRule . index.php [L]
+
+# END WordPress Multisite
+```
+
+### General Examples
+
+#### Options
+
+Any options preceded by a **+** are added to the options currently in force, and any options preceded by a **–** are removed from the options currently in force.
+
+Possible values for the [Options directive](https://httpd.apache.org/docs/trunk/mod/core.html#options) are any combination of:
+
+**None**
+
+All options are turned off.
+
+**All**
+
+All options except for MultiViews. This is the default setting.
+
+**ExecCGI**
+
+Execution of CGI scripts using mod_cgi is permitted.
+
+**FollowSymLinks**
+
+The server will follow symbolic links in this directory.
+
+**Includes**
+
+Server-side includes provided by mod_include are permitted.
+
+**IncludesNOEXEC**
+
+Server-side includes are permitted, but the #exec cmd and #exec cgi are disabled.
+
+**Indexes**
+
+URL maps to a directory, and no DirectoryIndex, a formatted listing of the directory.
+
+**MultiViews**
+
+Content negotiated “MultiViews” are allowed using mod_negotiation.
+
+**SymLinksIfOwnerMatch**
+
+Only follow symbolic links where target is owned by the same user id as the link.
+
+This will disable all options, and then only enable FollowSymLinks, which is necessary for mod\_rewrite.
+
+```
+Options None
+Options FollowSymLinks
+```
+
+#### DirectoryIndex
+
+[DirectoryIndex Directive](https://httpd.apache.org/docs/trunk/mod/mod_dir.html#directoryindex) sets the file that Apache will serve if a directory is requested.
+
+Several URLs may be given, in which case the server will return the first one that it finds.
+
+```
+DirectoryIndex index.php index.html /index.php
+```
+
+#### DefaultLanguage
+
+[DefaultLanguage Directive](https://httpd.apache.org/docs/trunk/mod/mod_mime.html#defaultlanguage) will cause all files that do not already have a specific language tag associated with it will use this.
+
+```
+DefaultLanguage en
+```
+
+#### Default Charset
+
+Set the default character encoding sent in the HTTP header. See [Setting charset information in .htaccess](https://www.w3.org/International/questions/qa-htaccess-charset)
+
+```
+AddDefaultCharset UTF-8
+```
+
+**Set Charset for Specific Files**
+
+```
+AddType 'text/html; charset=UTF-8' .html
+```
+
+**Set for specific files**
+
+```
+AddCharset UTF-8 .html
+```
+
+#### ServerSignature
+
+The [ServerSignature Directive](https://httpd.apache.org/docs/trunk/mod/core.html#serversignature) allows the configuration of a trailing footer line under server-generated documents. Optionally add a line containing the server version and virtual host name to server-generated pages (internal error documents, FTP directory listings, mod_status and mod_info output etc., but not CGI generated documents or custom error documents).
+
+**On**
+
+adds a line with the server version number and ServerName of the serving virtual host
+
+**Off**
+
+suppresses the footer line
+
+**Email**
+
+creates a “mailto:” reference to the ServerAdmin of the referenced document
+
+```
+SetEnv SERVER_ADMIN admin@site.com
+ServerSignature Email
+```
+
+#### Force Files to be Downloaded
+
+The below will cause any requests for files ending in the specified extensions to not be displayed in the browser but instead force a "Save As" dialog so the client can download.
+
+```
+AddType application/octet-stream .avi .mpg .mov .pdf .xls .mp4
+```
+
+#### HTTP Compression
+
+The [AddOutputFilter Directive](https://httpd.apache.org/docs/trunk/mod/mod_mime.html#addoutputfilter) maps the filename extension extension to the filters which will process responses from the server before they are sent to the client. This is in addition to any filters defined elsewhere, including `SetOutputFilter` and `AddOutputFilterByType`. This mapping is merged over any already in force, overriding any mappings that already exist for the same extension.
+
+See also [Enable Compression](https://developers.google.com/speed/docs/insights/EnableCompression)
+
+```
+AddOutputFilterByType DEFLATE text/html text/plain text/xml application/xml application/xhtml+xml text/javascript text/css application/x-javascript
+BrowserMatch ^Mozilla/4 gzip-only-text/html
+BrowserMatch ^Mozilla/4\.0[678] no-gzip
+BrowserMatch \bMSIE !no-gzip !gzip-only-text/html
+```
+
+**Force Compression for certain files**
+
+```
+SetOutputFilter DEFLATE
+```
+
+#### Send Custom HTTP Headers
+
+The [Header Directive](https://httpd.apache.org/docs/trunk/mod/mod_headers.html#header) lets you send HTTP headers for every request, or just specific files. You can view a sites HTTP Headers using [Firebug](https://getfirebug.com/), [Chrome Dev Tools](https://developer.chrome.com/docs/devtools/), [Wireshark](https://www.wireshark.org/) or [Advanced HTTP Request / Response Headers](https://www.askapache.com/online-tools/http-headers-tool/).
+
+```
+Header set X-Pingback "https://example.com/xmlrpc.php"
+Header set Content-Language "en-US"
+```
+
+#### Unset HTTP Headers
+
+This will unset HTTP headers, using **always** will try extra hard to remove them.
+
+```
+Header unset Pragma
+Header always unset WP-Super-Cache
+Header always unset X-Pingback
+```
+
+#### Password Protect Login
+
+This is very useful for protecting the `wp-login.php` file. You can use this [Advanced Htpasswd/Htdigest file creator](https://www.askapache.com/online-tools/htpasswd-generator/).
+
+**Basic Authentication**
+
+```
+AuthType Basic
+AuthName "Password Protected"
+AuthUserFile /full/absolute/path/to/.htpasswd
+Require valid-user
+Satisfy All
+```
+
+**Digest Authentication**
+
+```
+AuthType Digest
+AuthName "Password Protected"
+AuthDigestDomain /wp-login.php https://example.com/wp-login.php
+AuthUserFile /full/absolute/path/to/.htpasswd
+Require valid-user
+Satisfy All
+```
+
+#### Require Specific IP
+
+This is a way to only allow access for IP addresses listed. Note usage of RequireAny instead of RequireAll.
+
+```
+<RequireAny>
+  Require ip 192.0.2.123
+  Require ip 2001:0DB8:1111:2222:3333:4444:5555:6666
+</RequireAny>
+```
+
+#### Protect Sensitive Files
+
+This denies all web access to your wp-config file, htaccess/htpasswd and Wordpress debug.log. On installed site, consider adding install.php as well.
+
+```
+<FilesMatch "^(wp-config\.php|\.htaccess|\.htpasswd|debug\.log)$">
+  Require all denied
+</FilesMatch>
+```
+
+#### Require SSL
+
+This will force SSL, and require the exact hostname or else it will redirect to the SSL version. Useful in a `/wp-admin/.htaccess` file.
+
+```
+SSLOptions +StrictRequire
+SSLRequireSSL
+SSLRequire %{HTTP_HOST} eq "www.example.com"
+ErrorDocument 403 https://www.example.com
+```
+
+### External Resources
+
+* [Official Apache HTTP Server Tutorial: .htaccess files](https://httpd.apache.org/docs/trunk/howto/htaccess.html)
+* [Official Htaccess Directive Quick Reference](https://httpd.apache.org/docs/trunk/mod/quickreference.html)
+* [Htaccess Tutorial](https://www.askapache.com/htaccess/)
+* [Google PageSpeed for Developers](https://developers.google.com/speed/docs/insights/rules)
+* [Stupid Htaccess Tricks](https://perishablepress.com/stupid-htaccess-tricks/)
+* [Advanced Mod_Rewrite](https://www.askapache.com/htaccess/crazy-advanced-mod_rewrite-tutorial/)
+
+### See also
+
+* [htaccess for subdirectories](https://codex.wordpress.org/htaccess%20for%20subdirectories)
+* [Using Permalinks](https://wordpress.org/documentation/article/customize-permalinks/)
+* [Changing File Permissions](https://wordpress.org/documentation/article/changing-file-permissions/)
+* [UNIX Shell Skills](https://codex.wordpress.org/UNIX%20Shell%20Skills)
+* [Rewrite API](https://codex.wordpress.org/Rewrite%20API)
+

--- a/server/index.md
+++ b/server/index.md
@@ -1,0 +1,44 @@
+# Server configuration
+
+Server configuration covers the hosting environment that runs WordPress. This includes the web server, file and directory permissions, database tools, email delivery, domain routing, and hosting control panels.
+
+Use this section when you need to prepare a server for WordPress, adjust an existing server, or understand which server-level setting affects a WordPress feature. These pages are most useful for site administrators, hosting providers, and users who have access to server or hosting control panel settings.
+
+Some server changes can make a site unavailable if they are applied incorrectly. Review the relevant page before making changes and create a current backup when working with files or the database.
+
+## Choose a server topic
+
+- Use [Web servers](https://developer.wordpress.org/advanced-administration/server/web-server/) when you need to understand how WordPress works with server software such as Apache HTTPD or Nginx.
+- Use [Changing File Permissions](https://developer.wordpress.org/advanced-administration/server/file-permissions/) when WordPress cannot write files, updates fail, uploads fail, or you need to review ownership and permissions.
+- Use [Mail](https://developer.wordpress.org/advanced-administration/server/mail/) when WordPress email is not being sent or delivered reliably.
+- Use [Finding Server Info](https://developer.wordpress.org/advanced-administration/server/server-info/) when you need PHP, database, operating system, or server software details for installation or troubleshooting.
+- Use [Control Panels](https://developer.wordpress.org/advanced-administration/server/control-panel/) when your host provides tools such as WP Toolkit, cPanel, WHM, or Plesk.
+
+## Web server configuration
+
+The [Web servers](https://developer.wordpress.org/advanced-administration/server/web-server/) page explains the role of the web server and links to configuration guidance for Apache HTTPD and Nginx.
+
+- [Apache HTTPD / .htaccess](https://developer.wordpress.org/advanced-administration/server/web-server/httpd/) covers WordPress rewrite rules, `.htaccess` examples, and related Apache configuration.
+- [Nginx](https://developer.wordpress.org/advanced-administration/server/web-server/nginx/) covers standalone Nginx configuration for WordPress, including single site and multisite examples.
+
+## Files, directories, and database tasks
+
+- [Changing File Permissions](https://developer.wordpress.org/advanced-administration/server/file-permissions/) explains how file and directory permissions work and how they affect WordPress updates, uploads, plugins, themes, and configuration files.
+- [Emptying a Database Table](https://developer.wordpress.org/advanced-administration/server/empty-database/) explains how to empty a table with phpMyAdmin. This should only be done after confirming the correct table and creating a backup.
+- [Finding Server Info](https://developer.wordpress.org/advanced-administration/server/server-info/) explains how to collect server details such as PHP version, server software, and database version for installation or troubleshooting.
+
+## Domains, subdomains, and directory layout
+
+- [Giving WordPress Its Own Directory](https://developer.wordpress.org/advanced-administration/server/wordpress-in-directory/) explains how to keep WordPress core files in a subdirectory while serving the site from the domain root.
+- [Configuring Wildcard Subdomains](https://developer.wordpress.org/advanced-administration/server/subdomains-wildcard/) explains wildcard subdomain setup for domain-based multisite networks.
+
+## Mail and hosting tools
+
+- [Mail](https://developer.wordpress.org/advanced-administration/server/mail/) explains how WordPress sends email through the server environment and what administrators should consider for SMTP, relays, and deliverability.
+- [Control Panels](https://developer.wordpress.org/advanced-administration/server/control-panel/) covers common hosting control panel tools such as WP Toolkit for cPanel, WHM, and Plesk.
+
+## Before changing server settings
+
+If you are using managed hosting, check your host's documentation or support channels before changing server configuration. Hosts often manage web server rules, PHP settings, mail delivery, backups, and control panel features for you.
+
+For self-managed servers, test changes in a staging environment when possible. Keep a record of the original configuration so you can restore it if a change does not work as expected.

--- a/server/mail.md
+++ b/server/mail.md
@@ -1,0 +1,101 @@
+# Mail
+
+This page details the philosphy, operations, and the recommended practices for setting up the local mailing environment for WordPress.
+
+## Prerequisites
+
+Before starting, you'll need to have a basic understanding of the [SMTP protocol](https://en.wikipedia.org/wiki/Simple_Mail_Transfer_Protocol) and the roles of each of the three mailing agents ([MUA](https://en.wikipedia.org/wiki/Mail_user_agent), [MTA](https://en.wikipedia.org/wiki/Message_transfer_agent), and [MDA](https://en.wikipedia.org/wiki/Message_delivery_agent)).
+
+## WordPress's Philosophy on Mailing
+
+WordPress has never provided either a MUA or an MTA by default. It only provides a wrapper for a language API library that handles the submission of a message to an MTA which can interact either with PHP `mail()` function or the `SMTP` extension.
+
+This means, that its the server administrator's responsibility to configure the MTA and the related mailing environment properly to interact with the chosen language API. Historically, [PHPMailer](https://github.com/PHPMailer/PHPMailer) has been this library of choice. WordPress is not involved in the process of sending emails but only in the process of formatting the message to submit it to this mailing API.
+
+## How WordPress's Mailing operates out-of-the-box
+
+Currently, WordPress uses the `wp_mail()` wrapping function. By default configuration, this wrapper informs the PHPMailer library to use the PHP's internal `mail()` function that requires the presence of a sendmail-compatible binary acting as the MTA. Hence, in order for WordPress to work out-of-the-box, one needs to have the related mailing local environment properly configured.
+
+This is generally not a problem if you are using a managed hosting service, but if you are running your own server and do not have a SMTP server (MTA) set up and/or the related mailing environment properly configured, the outgoing mail won't be sent, unless you configure WordPress' wrapper to use a remote SMTP server.
+
+## Recommended Actions
+
+Besides the technical aspects, it's worthwhile to outline the recommended solutions given the different scenarios so the admins do not end up choosing solutions that don't fit them.
+
+If your WordPress site is on managed hosting, there is typically nothing extra that needs to be done to send emails, but some additional actions to ensure deliverability as explained below may be required. Mail originating from your WordPress install should work out-of-the-box. All mailing related questions should be directed to your webhost, and you may want to check if the host provides the option to configure a SMTP relay through their admin panel.
+
+If you're on a self-managed hosting platform (i.e. running your own server), there are typically three ways you can setup your mail service:
+
+- **Setup a local MTA or a dedicated mail server that can send mail directly**. With this method, you as the admin are responsible for everything. Please keep in mind that even if you've configured all of the related software correctly, you may still run into issues, as mail deliverability extends into factors outside of your control, such as IP reputation. Due to the amount of overhead and ongoing maintenance required, this method is typically reserved for server administrators with experience in this field, because of the potential to run into serious deliverability troubles.
+
+- **Setup a local MTA and have it relay mail to a third party mailing service**. This is the recommended method for most self-hosted setups because it is easier to implement than the previous one, and still retains compatibility with WordPress' philosophy. If you don't want to deal with the complexity of mail deliverability issues in running your full MTA, this is way to go. In fact, some smaller web hosts utilize this method (they would hold a business account with the third party mailing services and relay all the mails to the mailing service). If you host and manage your own site and you are sending a sizable number of emails through WordPress, this method is also ideal, as you delegate the responsibility to the third party mailing service. Like the first method, be aware that this option is not exempt of risks, as explained in the next section. Setting up your MTA always requires some level of server management expertise, even if you are relying on a third party mailing service.
+
+- **Configure a SMTP relay via code to utilize a third party mailing service**. This is the recommended method if you are not going to handle a high volume of emails or you don't want to deal with the complexity of mail deliverability issues in running a self-hosted MTA. Be aware that this method [will cause a performance degradation](https://konstantin.blog/2021/wp_mail-is-not-broken/) for many reasons.
+
+## Setting up your own MTA
+
+If you choose to set up your MTA, either for local or third party relay, this section briefly explains the basics of setting up an MTA in both *NIX and Windows environments. Before we go into the details, be aware that there are some risks in this approach. Port 25 has to be open, which can be problematic if you are not careful, as it is one of the most common attack vectors. If you don't protect the SMTP relay authentication properly, you might end up with a security issue or having your server being used for spamming.
+
+### *NIX Server Basics
+
+If you are running your own *NIX server, you should have either `postfix` `exim`, `qmail` or `sendmail` as the most popular MTA, on your machine and just need to set them up (you may search on the web for how-tos). If you wish to use a third party mailing service, the recommended practice is to setup your local MTA to relay mail to the remote SMTP server as this will prevent the page load time from suffering. 
+
+### Windows Host Server Specific
+
+Check your “Relay” settings on the SMTP Virtual Server. Grant access to `127.0.0.1` . Then in your `php.ini` file, set the `SMTP` setting to the same IP address. Also set `smtp_port` to `25`.
+
+On a Windows machine, try a sendmail emulator like [Fake sendmail for Windows with TLS v1.2 support](https://github.com/sendmail-tls1-2/main).
+
+### Alternative Solutions to MTA Setup
+
+If you do not want to manually setup a complete MTA in your box, there are some other options:
+
+* Use a relay MTA in place of a local full-featured MTA: for example, [msmtp-mta](https://wiki.debian.org/msmtp) is a simplified MTA that can be used to relay emails using a remote SMTP server (i.e. a remote MTA). The package provides a `/usr/sbin/sendmail` symlink to `msmtp` and has sendmail compatible interface that other software can use directly.  
+
+* Use SMTP plugins: You can install [SMTP plugins](https://wordpress.org/plugins/search/smtp/) from the WP.org plugin directory. These type of plugins override `wp_mail()` default settings to use PHPMailer or any other mailing library of their choice, which utlize remote third party mailing services to send mail on your behalf of your domain.
+
+### Ensuring Deliverability
+
+Once we have our system sending mails, we need to ensure that they are actually delivered to the recipients. There are a few things we need to check:
+
+#### Ensure Proper Return Address is Used
+
+By default, the WordPress wrapper fills in the `From:` field with `wordpress@example.com` and the `From:` name as *WordPress*. This is fine if this is a valid e-mail address. For example, if your domain is `example.com`, your host will pass `wordpress@example.com` on for delivery. It will probably send your mail as long as `example.com` is setup to send and receive mail, even if `wordpress` is not a valid mailbox. Some old mail delivery agents will check if the `From:` address is valid and can receive mail. This check is becoming less common nowadays, but we recommend to make sure to use a valid email address and the mailbox exists in your receiving mail server. If you are using the default `From:` address, simply verify that you can receive mail in the `wordpress@example.com` mailbox. Remember that `example.com` is the domain of your WordPress installation.
+
+If you don't want to send the emails from the same domain as the one exhibited in your installation, then you must introduce some code changes in your WordPress. For example, if your WP domain is `example.org` but you want to send emails from `mail.example.org`, the mail may not send because the DNS records of `example.org` may not authorize emails to be handled by your mail server, as the default `From:` address will be `wordpress@wordpress.org`. To change the default `From:` address, your WordPress can [use the `wp_mail_from` filter](https://developer.wordpress.org/reference/hooks/wp_mail_from/). For the name, you can use [the `wp_mail_from_name` filter](https://developer.wordpress.org/reference/hooks/wp_mail_from_name/). 
+
+It may be possible to force the `From:` address configuration in your configured MTA server. Refer to the related documentation for your MTA.
+
+#### The Reply-To Address
+
+The WordPress wrapper ignores the `Reply-To:`, so it will be coincidental with the `From:` address, following the example above, `wordpress@example.com` by default. If you want your users to be able to reply to sent emails, make sure that this mailbox exists on your receiving mail server. The default `Reply-To:` is always going to be the same as the `From:` address, unless you explicitly set it to a different address in the mail headers. 
+
+There is only one scenario where the `Reply-To:` address is set automatically: when we are sending an email to a user that commented on a post. In this case, the `Reply-To:` address will be set to the email address that the commenter explicitely specified.
+
+### Troubleshooting Spam Deliverability Issues
+
+Your email message may have been routed to a spam folder or even worse, simply discarded as malicious. There are a couple measures you can use to convince recipient’s mail servers that your message is legitimate and should be delivered as addressed. Setting up SPF, DKIM and DMARC records is a critical step to ensure deliverability. There are multiple guides online that will help you set up these records. Below is an explanation as to why these records are beneficial.
+
+#### SPF (Sender Policy Framework)
+
+This is the most common anti-spam measure used. The MDA checks the SPF record of the sender's domain to see if it is authorized to send mail for that domain. The SPF is a TXT DNS record that you need to add, or check if your host has added it for you, that lists the IP addresses or hostnames authorized to send mail for that domain. This ensures that the mail is not coming from an unauthorized source. So, for example, if an unknown server IP address sends an email with your domain name in the `From:` field, thanks to the SPF DNS record, the MDA will reject the mail as spam. But if you don't configure this properly in your DNS records, your emails may also be rejected as spam.
+
+Just remember, if you are sending emails through different servers, including your WordPress installation, you need to add all the addresses to the SPF record.
+
+#### DKIM (Domain Key Identified Mail)
+
+This anti-spam integrity authentication check has gained a lot of traction in the last few years, and has been implemented by most major email providers. You can use both SPF and DKIM in the same message. Again, just as with SPF, you can check if your receiving mailserver verified your host’s domain key by examining the mail header. As with SPF, if you can edit your TXT DNS records, you can set up DKIM credentials yourself. If you are in a managed hosting environment, check with your hosting provider if they have set this up for you, as it is common practice.
+
+If you have to manage this by yourself, there are multiple methods to send the right DKIM signature in your emails:
+
+* Configure your MTA to sign the email with the DKIM signature. 
+
+* Some SMTP plugins have a DKIM signature option.
+
+* Use `PHPMailer` library to set the DKIM signature. For this, you may need to [hook to the `phpmailer_init` action](https://developer.wordpress.org/reference/hooks/phpmailer_init/) and follow the PHPMailer library's documentation (this is not officially documented, check [this post for more details](https://stackoverflow.com/a/24464694/4442122).
+
+Also make sure to generate your DKIM keys with the correct domain information and publish the DNS record accordingly. When you add the DKIM public key to your DNS records, the MDA will check for your email header DKIM-Signature and verify the signature. If the signature is invalid, the MDA will reject the mail as spam. This is meant to avoid emails being spoofed and sent from an unauthorized source. DKIM and SPF are used together to ensure the email is legitimate and should be delivered as addressed.
+
+#### DMARC (Domain-based Message Authentication, Reporting & Conformance)
+
+The DMARC record is another TXT DNS record that you need to add or check if your hosting has added it for you, that lists the actions to take when the email has not passed the SPF or DKIM checks. DMARC is becoming almost mandatory, so to ensure deliverability, we recommend setting it up. You can read more about it [here](https://dmarc.org/).

--- a/server/nginx.md
+++ b/server/nginx.md
@@ -1,0 +1,695 @@
+# Nginx
+
+While the LAMP stack (Linux + Apache + MySQL + PHP) is very popular for powering WordPress, it is also possible to use Nginx. WordPress supports Nginx, and some large WordPress sites, such as WordPress.com, are powered by Nginx.
+
+When talking about Nginx, it is important to know that there are multiple ways to implement Nginx. It can be setup as a reverse-proxy in front of Apache, which is a very powerful setup that allows you to use all of the features and power of Apache, while benefiting from the speed of Nginx. Most websites that report using Nginx as the server (based on stats gathered from HTTP response headers), are actually Apache running with Nginx as the reverse proxy. (The HTTP response headers showing “Nginx” are being reported by the reverse-proxy, not the server itself.)
+
+**This guide is referring to a standalone Nginx setup, where it is used as the primary server instead of Apache.** It should be noted that Nginx is not a completely interchangeable substitute for Apache. There are a few key differences affecting WordPress implementation that you need to be aware of before you proceed:
+
+- With Nginx there is no directory-level configuration file like Apache’s .htaccess or IIS’s web.config files. All configuration has to be done at the server level by an administrator, and WordPress cannot modify the configuration, like it can with Apache or IIS.
+- Pretty Permalinks functionality is slightly different when running Nginx.
+- Since Nginx does not have .htaccess-type capability and WordPress cannot automatically modify the server configuration for you, it cannot generate the rewrite rules for you.
+- Without modifications to your install, “index.php” will be added to your Permalinks. (There are ways to mitigate this with plugins (see below) and/or adding custom code to your child theme’s functions.php.)
+- However, if you do want to have some (limited) .htaccess capability, it is technically possible to do add by installing the [htscanner PECL extension for PHP](https://www.php.net/manual/en/book.htscanner.php). (However, this is not a perfect solution so be sure to test and debug thoroughly before using on a live site.)
+
+This guide is not going to cover how to install and configure Nginx, so this assumes that you have already installed Nginx and have a basic understanding of how to work with and debug it.
+
+## Generic and Multi-Site Support
+
+To make WordPress work with Nginx you have to configure the backend php-cgi. The options available are `fastcgi` or `php-fpm`. Here, php-fpm is being used because it is included with PHP 5.3+, so installing it is straight forward.
+
+The Nginx configuration has been broken up into five distinct files and is heavily commented to make each option easier to understand. The [author](https://wordpress.org/support/users/bigsite/) also made a best-effort attempting to follow “best practices” for nginx configurations.
+
+### Main (generic) startup file
+
+This is equivalent to /etc/nginx/nginx.conf (or /etc/nginx/conf/nginx.conf if you’re using Arch Linux).
+
+```
+# Generic startup file.
+user {user} {group};
+
+#usually equal to number of CPUs you have. run command "grep processor /proc/cpuinfo | wc -l" to find it
+worker_processes  auto;
+worker_cpu_affinity auto;
+
+error_log  /var/log/nginx/error.log;
+pid        /var/run/nginx.pid;
+
+# Keeps the logs free of messages about not being able to bind().
+#daemon     off;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    #rewrite_log on;
+
+    include mime.types;
+    default_type       application/octet-stream;
+    access_log         /var/log/nginx/access.log;
+    sendfile           on;
+    #tcp_nopush         on;
+    keepalive_timeout  3;
+    #tcp_nodelay        on;
+    #gzip               on;
+    #php max upload limit cannot be larger than this
+    client_max_body_size 13m;
+    index              index.php index.html index.htm;
+
+    # Upstream to abstract backend connection(s) for PHP.
+    upstream php {
+        #this should match value of "listen" directive in php-fpm pool
+        server unix:/tmp/php-fpm.sock;
+        # server 127.0.0.1:9000;
+    }
+
+    include sites-enabled/*;
+}
+```
+
+### Per Site configuration
+
+```
+# Redirect everything to the main site. We use a separate server statement and NOT an if statement - see https://www.nginx.com/resources/wiki/start/topics/depth/ifisevil/
+
+server {
+    server_name  _;
+    return 302 $scheme://example.com$request_uri;
+}
+
+server {
+    server_name example.com;
+    root /var/www/example.com;
+
+    index index.php;
+
+    include global/restrictions.conf;
+
+    # Additional rules go here.
+
+    # Only include one of the files below.
+    include global/wordpress.conf;
+    # include global/wordpress-ms-subdir.conf;
+    # include global/wordpress-ms-subdomain.conf;
+}
+```
+
+Splitting sections of the configuration into multiple files allows the same logic to be reused over and over. A ‘global’ subdirectory is used to add extra rules for general purpose use (either /etc/nginx/conf/global/ or /etc/nginx/global/ depending on how your nginx install is set up).
+
+### Global restrictions file
+
+```
+# Global restrictions configuration file.
+# Designed to be included in any server {} block.
+location = /favicon.ico {
+    log_not_found off;
+    access_log off;
+}
+
+location = /robots.txt {
+    allow all;
+    log_not_found off;
+    access_log off;
+}
+
+# Deny all attempts to access hidden files such as .htaccess, .htpasswd, .DS_Store (Mac).
+# Keep logging the requests to parse later (or to pass to firewall utilities such as fail2ban)
+location ~ /\. {
+    deny all;
+}
+
+# Deny access to any files with a .php extension in the uploads directory
+# Works in sub-directory installs and also in multisite network
+# Keep logging the requests to parse later (or to pass to firewall utilities such as fail2ban)
+location ~* /(?:uploads|files)/.*\.php$ {
+    deny all;
+}
+```
+
+### General WordPress rules
+
+For single site installations, here is the `global/wordpress.conf` file:
+
+```
+# WordPress single site rules.
+# Designed to be included in any server {} block.
+# Upstream to abstract backend connection(s) for php
+upstream php {
+    server unix:/tmp/php-cgi.socket;
+    server 127.0.0.1:9000;
+}
+
+server {
+    ## Your website name goes here.
+    server_name domain.tld;
+    ## Your only path reference.
+    root /var/www/wordpress;
+    ## This should be in your http block and if it is, it's not needed here.
+    index index.php;
+
+    location = /favicon.ico {
+        log_not_found off;
+        access_log off;
+    }
+
+    location = /robots.txt {
+        allow all;
+        log_not_found off;
+        access_log off;
+    }
+
+    location / {
+        # This is cool because no php is touched for static content.
+        # include the "?$args" part so non-default permalinks doesn't break when using query string
+        try_files $uri $uri/ /index.php?$args;
+    }
+
+    location ~ \.php$ {
+        #NOTE: You should have "cgi.fix_pathinfo = 0;" in php.ini
+        include fastcgi.conf;
+        fastcgi_intercept_errors on;
+        fastcgi_pass php;
+    }
+
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico)$ {
+        expires max;
+        log_not_found off;
+    }
+}
+```
+
+This is more up-to-date example for Nginx: https://www.nginx.com/resources/wiki/start/topics/recipes/wordpress/
+
+### WordPress Multisite
+
+For multisite installations, use one of the below sections for the `global/wordpress.conf` file, depending on the version of WordPress that was in use when multisite was *activated*, as well as the domain/subdirectory configuration.
+
+#### WordPress 3.5 and up
+
+If you activated Multisite on WordPress 3.5 or later, use one of these.
+
+##### WordPress 3.5 and up Subdirectory Examples
+
+```
+# WordPress multisite subdirectory config file for WP 3.5 and up.
+server {
+    server_name example.com ;
+
+    root /var/www/example.com/htdocs;
+    index index.php;
+
+    if (!-e $request_filename) {
+        rewrite /wp-admin$ $scheme://$host$request_uri/ permanent;
+        rewrite ^(/[^/]+)?(/wp-.*) $2 last;
+        rewrite ^(/[^/]+)?(/.*\.php) $2 last;
+    }
+
+    location / {
+        try_files $uri $uri/ /index.php?$args ;
+    }
+
+    location ~ \.php$ {
+        try_files $uri =404;
+        include fastcgi_params;
+        fastcgi_pass php;
+    }
+
+    #add some rules for static content expiry-headers here
+}
+```
+
+##### WordPress 3.5 and up Subdomains Examples
+
+```
+# WordPress multisite subdomain config file for WP 3.5 and up.
+server {
+    server_name example.com *.example.com ;
+
+    root /var/www/example.com/htdocs;
+    index index.php;
+
+    location / {
+        try_files $uri $uri/ /index.php?$args ;
+    }
+
+    location ~ \.php$ {
+        try_files $uri =404;
+        include fastcgi_params;
+        fastcgi_pass php;
+    }
+
+    #add some rules for static content expiry-headers here
+}
+```
+
+#### WordPress 3.4 and below
+
+If you originally activated Multisite with WordPress with 3.4 or older, you need to use one of these:
+
+##### WordPress <=3.4 Subdirectory Examples
+
+```
+# WordPress multisite subdirectory config file for WP 3.4 and below.
+
+map $uri $blogname{
+    ~^(?P<blogpath>/[^/]+/)files/(.*)       $blogpath ;
+}
+
+map $blogname $blogid{
+    default -999;
+
+    #Ref: https://wordpress.org/extend/plugins/nginx-helper/
+    #include /var/www/wordpress/wp-content/plugins/nginx-helper/map.conf ;
+}
+
+server {
+    server_name example.com ;
+
+    root /var/www/example.com/htdocs;
+    index index.php;
+
+    location ~ ^(/[^/]+/)?files/(.+) {
+        try_files /wp-content/blogs.dir/$blogid/files/$2 /wp-includes/ms-files.php?file=$2 ;
+        access_log off;     log_not_found off; expires max;
+    }
+
+    #avoid php readfile()
+    location ^~ /blogs.dir {
+        internal;
+        alias /var/www/example.com/htdocs/wp-content/blogs.dir ;
+        access_log off;     log_not_found off; expires max;
+    }
+
+    if (!-e $request_filename) {
+        rewrite /wp-admin$ $scheme://$host$request_uri/ permanent;
+        rewrite ^(/[^/]+)?(/wp-.*) $2 last;
+        rewrite ^(/[^/]+)?(/.*\.php) $2 last;
+    }
+
+    location / {
+        try_files $uri $uri/ /index.php?$args ;
+    }
+
+    location ~ \.php$ {
+        try_files $uri =404;
+        include fastcgi_params;
+        fastcgi_pass php;
+    }
+
+    #add some rules for static content expiry-headers here
+}
+```
+
+NGINX provides 2 special directive: X-Accel-Redirect and map. Using these 2 directives, one can eliminate performance hit for static-file serving on WordPress multisite network.
+
+##### WordPress <=3.4 Subdomains Examples
+
+```
+# WordPress multisite subdomain config file for WP 3.4 and below.
+map $http_host $blogid {
+    default       -999;
+
+    #Ref: https://wordpress.org/extend/plugins/nginx-helper/
+    #include /var/www/wordpress/wp-content/plugins/nginx-helper/map.conf ;
+
+}
+
+server {
+    server_name example.com *.example.com ;
+
+    root /var/www/example.com/htdocs;
+    index index.php;
+
+    location / {
+        try_files $uri $uri/ /index.php?$args ;
+    }
+
+    location ~ \.php$ {
+        try_files $uri =404;
+        include fastcgi_params;
+        fastcgi_pass php;
+    }
+
+    #WPMU Files
+        location ~ ^/files/(.*)$ {
+            try_files /wp-content/blogs.dir/$blogid/$uri /wp-includes/ms-files.php?file=$1 ;
+            access_log off; log_not_found off; expires max;
+        }
+
+    #WPMU x-sendfile to avoid php readfile()
+    location ^~ /blogs.dir {
+        internal;
+        alias /var/www/example.com/htdocs/wp-content/blogs.dir;
+        access_log off;     log_not_found off;      expires max;
+    }
+
+    #add some rules for static content expiry-headers here
+}
+```
+
+Ref: https://www.nginx.com/resources/wiki/start/topics/recipes/wordpress/
+
+### HTTPS in Nginx
+
+Enabling HTTPS in Nginx is relatively simple.
+
+```
+server {
+    # listens both on IPv4 and IPv6 on 443 and enables HTTPS and HTTP/2 support.
+    # HTTP/2 is available in nginx 1.9.5 and above.
+    listen *:443 ssl;
+    listen [::]:443 ssl;
+    http2 on;
+
+    # indicate locations of SSL key files.
+    ssl_certificate /srv/www/ssl/ssl.crt;
+    ssl_certificate_key /srv/www/ssl/ssl.key;
+    ssl_dhparam /srv/www/master/ssl/dhparam.pem;
+
+    # indicate the server name
+    server_name example.com *.example.com;
+
+    # Enable HSTS. This forces SSL on clients that respect it, most modern browsers. The includeSubDomains flag is optional.
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains";
+
+    # Set caches, protocols, and accepted ciphers. This config will merit an A+ SSL Labs score as of Sept 2015.
+    ssl_session_cache shared:SSL:20m;
+    ssl_session_timeout 10m;
+    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+    ssl_prefer_server_ciphers on;
+    ssl_ciphers 'ECDH+AESGCM:ECDH+AES256:ECDH+AES128:DH+3DES:!ADH:!AECDH:!MD5';
+}
+```
+
+Mozilla offers an [excellent SSL config generation tool](https://mozilla.github.io/server-side-tls/ssl-config-generator/) as well.
+
+### WP Super Cache Rules
+
+```
+# WP Super Cache rules.
+# Designed to be included from a 'wordpress-ms-...' configuration file.
+
+set $cache_uri $request_uri;
+
+# POST requests and urls with a query string should always go to PHP
+if ($request_method = POST) {
+    set $cache_uri 'null cache';
+}
+
+if ($query_string != "") {
+    set $cache_uri 'null cache';
+}
+
+# Don't cache uris containing the following segments
+if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|/wp-(app|cron|login|register|mail).php|wp-.*.php|/feed/|index.php|wp-comments-popup.php|wp-links-opml.php|wp-locations.php|sitemap(_index)?.xml|[a-z0-9_-]+-sitemap([0-9]+)?.xml)") {
+    set $cache_uri 'null cache';
+}
+
+# Don't use the cache for logged in users or recent commenters
+if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_logged_in") {
+    set $cache_uri 'null cache';
+}
+
+# START MOBILE
+# Mobile browsers section to server them non-cached version. COMMENTED by default as most modern wordpress themes including twenty-eleven are responsive. Uncomment config lines in this section if you want to use a plugin like WP-Touch
+# if ($http_x_wap_profile) {
+    # set $cache_uri 'null cache';
+#}
+
+#if ($http_profile) {
+    # set $cache_uri 'null cache';
+#}
+
+#if ($http_user_agent ~* (2.0\ MMP|240x320|400X240|AvantGo|BlackBerry|Blazer|Cellphone|Danger|DoCoMo|Elaine/3.0|EudoraWeb|Googlebot-Mobile|hiptop|IEMobile|KYOCERA/WX310K|LG/U990|MIDP-2.|MMEF20|MOT-V|NetFront|Newt|Nintendo\ Wii|Nitro|Nokia|Opera\ Mini|Palm|PlayStation\ Portable|portalmmm|Proxinet|ProxiNet|SHARP-TQ-GX10|SHG-i900|Small|SonyEricsson|Symbian\ OS|SymbianOS|TS21i-10|UP.Browser|UP.Link|webOS|Windows\ CE|WinWAP|YahooSeeker/M1A1-R2D2|iPhone|iPod|Android|BlackBerry9530|LG-TU915\ Obigo|LGE\ VX|webOS|Nokia5800)) {
+    # set $cache_uri 'null cache';
+#}
+
+#if ($http_user_agent ~* (w3c\ |w3c-|acs-|alav|alca|amoi|audi|avan|benq|bird|blac|blaz|brew|cell|cldc|cmd-|dang|doco|eric|hipt|htc_|inno|ipaq|ipod|jigs|kddi|keji|leno|lg-c|lg-d|lg-g|lge-|lg/u|maui|maxo|midp|mits|mmef|mobi|mot-|moto|mwbp|nec-|newt|noki|palm|pana|pant|phil|play|port|prox|qwap|sage|sams|sany|sch-|sec-|send|seri|sgh-|shar|sie-|siem|smal|smar|sony|sph-|symb|t-mo|teli|tim-|tosh|tsm-|upg1|upsi|vk-v|voda|wap-|wapa|wapi|wapp|wapr|webc|winw|winw|xda\ |xda-)) {
+    # set $cache_uri 'null cache';
+#}
+#END MOBILE
+
+# Use cached or actual file if they exists, otherwise pass request to WordPress
+location / {
+    try_files /wp-content/cache/supercache/$http_host/$cache_uri/index.html $uri $uri/ /index.php?$args ;
+}
+```
+
+**Experimental modifications:**
+
+If you are using HTTPS, the latest development version of WP Super Cache may use a different directory structure to differentiate between HTTP and HTTPS. try_files line may look like below:
+
+```
+location / {
+    try_files /wp-content/cache/supercache/$http_host/$cache_uri/index-https.html $uri $uri/ /index.php?$args ;
+}
+```
+
+### W3 Total Cache Rules
+
+W3 Total Cache uses different directory structure for disk-based cache storage depending on WordPress configuration.
+
+Cache validation checks will remain common as shown below:
+
+```
+#W3 TOTAL CACHE CHECK
+set $cache_uri $request_uri;
+
+# POST requests and urls with a query string should always go to PHP
+if ($request_method = POST) {
+    set $cache_uri 'null cache';
+}
+if ($query_string != "") {
+    set $cache_uri 'null cache';
+}
+
+# Don't cache uris containing the following segments
+if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|/wp-(app|cron|login|register|mail).php|wp-.*.php|/feed/|index.php|wp-comments-popup.php|wp-links-opml.php|wp-locations.php|sitemap(_index)?.xml|[a-z0-9_-]+-sitemap([0-9]+)?.xml)") {
+    set $cache_uri 'null cache';
+}
+
+# Don't use the cache for logged in users or recent commenters
+if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_logged_in") {
+    set $cache_uri 'null cache';
+}
+#ADD mobile rules from WP SUPER CACHE section above
+
+#APPEND A CODE BLOCK FROM BELOW...
+```
+
+**FOR Normal WordPress (without Multisite)**
+
+Use following:
+
+```
+# Use cached or actual file if they exists, otherwise pass request to WordPress
+location / {
+    try_files /wp-content/w3tc/pgcache/$cache_uri/_index.html $uri $uri/ /index.php?$args ;
+}
+```
+
+**FOR Multisite with subdirectories**
+Use the following:
+
+```
+if ( $request_uri ~* "^/([_0-9a-zA-Z-]+)/.*" ){
+    set $blog $1;
+}
+
+set $blog "${blog}.";
+
+if ( $blog = "blog." ){
+    set $blog "";
+}
+
+# Use cached or actual file if they exists, otherwise pass request to WordPress
+location / {
+    try_files /wp-content/w3tc-$blog$host/pgcache$cache_uri/_index.html $uri $uri/ /index.php?$args ;
+}
+```
+
+**FOR Multisite with Subdomains/Domain-mapping**
+Use following:
+
+```
+location / {
+    try_files /wp-content/w3tc-$host/pgcache/$cache_uri/_index.html $uri $uri/ /index.php?$args;
+}
+```
+
+Notes
+
+- Nginx can handle gzip & browser cache automatically so better leave that part to nginx.
+- W3 Total Cache Minify rules will work with above config without any issues.
+
+## Nginx fastcgi_cache
+
+Nginx can perform caching on its own end to reduce load on your server. When you want to use Nginx’s built-in fastcgi_cache, you better compile nginx with [fastcgi_cache_purge](https://github.com/FRiCKLE/ngx_cache_purge) module. It will help nginx purge cache for a page when it gets edited. On the WordPress side, you need to install a plugin like [Nginx Helper](https://wordpress.org/plugins/nginx-helper/) to utilize fastcgi_cache_purge feature.
+
+Config will look like below:
+
+**Define a Nginx cache zone in http{…} block, outside server{…} block**
+
+```
+#move next 3 lines to /etc/nginx/nginx.conf if you want to use fastcgi_cache across many sites
+fastcgi_cache_path /var/run/nginx-cache levels=1:2 keys_zone=WORDPRESS:500m inactive=60m;
+fastcgi_cache_key "$scheme$request_method$host$request_uri";
+fastcgi_cache_use_stale error timeout invalid_header http_500;
+```
+
+**For WordPress site config, in server{..} block add a cache check block as follow**
+
+```
+#fastcgi_cache start
+set $no_cache 0;
+
+# POST requests and urls with a query string should always go to PHP
+if ($request_method = POST) {
+    set $no_cache 1;
+}
+if ($query_string != "") {
+    set $no_cache 1;
+}
+
+# Don't cache uris containing the following segments
+if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|/wp-(app|cron|login|register|mail).php|wp-.*.php|/feed/|index.php|wp-comments-popup.php|wp-links-opml.php|wp-locations.php|sitemap(_index)?.xml|[a-z0-9_-]+-sitemap([0-9]+)?.xml)") {
+        set $no_cache 1;
+}
+
+# Don't use the cache for logged in users or recent commenters
+if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_no_cache|wordpress_logged_in") {
+        set $no_cache 1;
+}
+```
+
+**Then make changes to PHP handling block**
+
+Just add this to the following php block. Note the line fastcgi_cache_valid 200 60m; which tells nginx only to cache 200 responses(normal pages), which means that redirects are not cached. This is important for multilanguage sites where, if not implemented, nginx would cache the main url in one language instead of redirecting users to their respective content according to their language.
+
+```
+fastcgi_cache_bypass $no_cache;
+fastcgi_no_cache $no_cache;
+
+fastcgi_cache WORDPRESS;
+fastcgi_cache_valid 200 60m;
+```
+
+Such that it becomes something like this
+
+```
+location ~ [^/]\.php(/|$) {
+    fastcgi_split_path_info ^(.+?\.php)(/.*)$;
+    if (!-f $document_root$fastcgi_script_name) {
+        return 404;
+    }
+    # This is a robust solution for path info security issue and works with "cgi.fix_pathinfo = 1" in /etc/php.ini (default)
+
+    include fastcgi.conf;
+    fastcgi_index index.php;
+    # fastcgi_intercept_errors on;
+    fastcgi_pass php;
+
+    fastcgi_cache_bypass $no_cache;
+    fastcgi_no_cache $no_cache;
+
+    fastcgi_cache WORDPRESS;
+    fastcgi_cache_valid 200 60m;
+}
+```
+
+**Finally add a location for conditional purge**
+
+```
+location ~ /purge(/.*) {
+    # Uncomment the following two lines to allow purge only from the webserver
+    # allow 127.0.0.1;
+    # deny all;
+
+    fastcgi_cache_purge WORDPRESS "$scheme$request_method$host$1";
+}
+```
+
+If you get an ‘unknown directive “fastcgi_cache_purge”‘ error check that your Nginx installation has fastcgi_cache_purge module.
+
+## Better Performance for Static Files in Multisite (WP <= 3.4)
+
+By default, on multisite networks activated prior to 3.5, a static file request brings php into picture i.e. `ms-files.php` file. You can get much better performance using Nginx `Map{..}` directive.
+
+In Nginx config for your site, above `server{..}` block, add a section as follows:
+
+```
+map $http_host $blogid {
+    default               0;
+
+    example.com           1;
+    site1.example.com     2;
+    site1.com             2;
+}
+```
+
+It is just a list of site-names and blog-ids. You can use [Nginx helper](https://wordpress.org/extend/plugins/nginx-helper) to get such a list of site-name/blog-id pairs. This plugin will also generate a `map.conf` file which you can directly include in the `map{}` section like this:
+
+```
+map $http_host $blogid {
+    default               0;
+
+    include /path/to/map.conf ;
+}
+```
+
+After creating a `map{..}` section, you just need to make one more change in your Nginx config so requests for /files/ will be first processed using nginx `map{..}`:
+
+```
+location ~ ^/files/(.*)$ {
+    try_files /wp-content/blogs.dir/$blogid/$uri /wp-includes/ms-files.php?file=$1 ;
+    access_log off; log_not_found off; expires max;
+}
+```
+
+Notes
+
+- Whenever a new site is created, deleted or an extra domain is mapped to an existing site, Nginx helper will update map.conf file automatically but you will still need to reload Nginx config manually. You can do that anytime later. Till then, only files for new sites will be served using php-fpm.
+- This method does not generate any symbolic links. So, there will be no issues with accidental deletes or backup scripts that follow symbolic links.
+- For large networks, this will scale-up nicely as there will be a single map.conf file.
+
+A couple of final but important notes: This whole setup assumes that the root of the site is the blog and that all files that will be referenced reside on the host. If you put the blog in a subdirectory such as /blog, then the rules will have to be modified. Perhaps someone can take these rules and make it possible to, for instance, use a:
+
+```
+set $wp_subdir "/blog";
+```
+
+directive in the main ‘server’ block and have it automagically apply to the generic WP rules.
+
+## Warning
+
+A typo in [Global restrictions file](https://developer.wordpress.org/advanced-administration/server/web-server/nginx/#global-restrictions-file) can create loopholes. To test if your “uploads” directory is really protected, create a PHP file with some content (example: <?php phpinfo(); ?>), upload it to “uploads” directory (or one of its sub-directories), then try to access (execute) it from your browser.
+
+## Resources
+
+### Reference
+
+- [nginx + php-fpm + PHP APC + WordPress multisite (subdirectory) + WP Super Cache](https://wordpress.org/support/topic/nginx-php-fpm-php-apc-wordpress-multisite-subdirectory-wp-super-cache/).
+
+### External Links
+
+- [Nginx WordPress wiki page](https://www.nginx.com/resources/wiki/start/topics/recipes/wordpress/)
+- [LEMP guides on Linode’s Library](https://www.linode.com/docs/guides/web-servers/lemp/)
+- [Various guides about Nginx on Linode’s Library](https://www.linode.com/docs/guides/web-servers/nginx/)
+- [Lightning fast WordPress with Php-fpm and Nginx](https://www.sitepoint.com/lightning-fast-wordpress-with-php-fpm-and-nginx/)
+- [Virtual Hosts Examples](https://wiki.nginx.org/VirtualHostExample)
+- [List of 20+ WordPress-Nginx Tutorials for common situations](https://rtcamp.com/wordpress-nginx/tutorials/)
+- [An introduction to Nginx configuration](https://blog.martinfjordvald.com/nginx-primer/)
+- [A comprehensive blog series on hosting WordPress yourself using Nginx](https://deliciousbrains.com/hosting-wordpress-setup-secure-virtual-server/)
+- [WordPress Installation CentminMod](https://centminmod.com/nginx_configure_wordpress.html)
+- [Nginx WordPress Installation Guide](https://thecustomizewindows.com/2015/12/nginx-wordpress-installation-guide-steps/)
+
+### Scripts & Tools
+
+For WordPress Nginx scripted installation [CentminMod](https://centminmod.com/nginx_configure_wordpress.html) can be used for CentOS.
+
+### Securing Nginx
+
+- [Securing Nginx and PHP](http://kbeezie.com/securing-nginx-php/)
+- [Setting up PHP-FastCGI and nginx? Don’t trust the tutorials: check your configuration!](https://nealpoole.com/blog/2011/04/setting-up-php-fastcgi-and-nginx-dont-trust-the-tutorials-check-your-configuration/)
+

--- a/server/subdomains-wildcard.md
+++ b/server/subdomains-wildcard.md
@@ -1,0 +1,57 @@
+# Configuring Wildcard Subdomains
+
+Wildcard subdomains are useful to allow end users of a domain-based WordPress [multisite](https://wordpress.org/documentation/article/wordpress-glossary/#multisite) network to create new sites on demand. In this type of network each new site has its own subdomain, and the wildcard configuration means that those subdomains do not have to be configured individually. For information on how to create a multisite network, see: [Create A Network](https://developer.wordpress.org/advanced-administration/multisite/create-network/).
+
+This page contains some examples of how to configure wildcard subdomains in different circumstances. If you cannot determine how to set up wildcard subdomains on your particular web server, *contact your webhost* for directions.
+
+## Apache {#apache}
+
+In the `httpd.conf` file, or in the include file containing the `VirtualHost` section for your web account, add a line like this (if it is not already present):
+
+```
+ServerAlias *.example.com
+```
+
+Also create a wildcard DNS record like:
+
+```
+*.example.com A 192.0.2.1
+```
+
+## CPanel {#cpanel}
+
+Make a sub-domain named "*" (wildcard) at your CPanel (`*.example.com`). Make sure to point this at the same folder location where your `wp-config.php` file is located.
+
+## Plesk {#plesk}
+
+There are several steps that differ when setting up the server for wildcard subdomains on a server using Plesk Panel compared to a server using cPanel (or no control panel). This article [Configuring Wildcard Subdomains for multi site under Plesk Control Panel](https://codex.wordpress.org/Configuring_Wildcard_Subdomains_for_multi_site_under_Plesk_Control_Panel) details all the steps involved.
+
+## DirectAdmin {#directadmin-panel}
+
+Click "User Panel" -> DNS Management -> add the following three entries using the three columns:
+
+```
+* A 192.0.2.1
+```
+
+Click "Admin Panel" (If you have no "admin panel" ask your host to do this) -> Custom Httpd -> yourdomain.com -> In the text input area, just paste and "save" precisely the following:
+
+```
+ServerAlias *.|DOMAIN|
+```
+
+_If you ever need to un-do a custom Httpd: return here, delete text from input area, save._
+
+- DirectAdmin.com: [Apache Wildcard Documentation](https://help.directadmin.com/item.php?id=127). DirectAdmin.com forum: [WordPress wildcard subdomains](https://forum.directadmin.com/threads/wildcard-subdomains-yea-i-know-its-a-common-one.29074/#post-195033).
+
+## Amazon Web Services {#amazon-web-services}
+
+AWS instances are not assigned a permanent IP address by default. This means that a "server's" IP address may change when it is rebooted. To resolve this issue, assign an Elastic IP Address to your server instance and use that IP address when configuring the A record with your registrar.
+
+AWS Elastic Load Balancers cannot be assigned an elastic IP, therefore you must use a CName to give them a friendly URL. You cannot have a CName to a root URL. Therefore you must point the domain root (example.com) at a specific server instance with an Elastic IP address and create a wildcard CName (*.example.com) and point that at your Elastic Load Balancer. In your .htaccess, then just redirect all domain root traffic (example.com) to a specific sub-domain (www.example.com).
+
+**Notes:**
+
+- Some registrars do not currently support wildcard CNames.
+- Amazon's Route53 Domain Name Service eliminates the CName issue, but at an additional cost.
+

--- a/server/wordpress-in-directory.md
+++ b/server/wordpress-in-directory.md
@@ -1,0 +1,119 @@
+# Giving WordPress Its Own Directory
+
+Many people want WordPress to power their website's root (e.g. https://example.com) but they don't want all of the WordPress files cluttering up their root directory. WordPress allows you to install it into a subdirectory, but have your website served from the website root.
+
+**Note:** This guide covers configuration for Apache (`.htaccess`), nginx (server blocks), and IIS (`web.config`).
+
+As of [Version 3.5](https://wordpress.org/documentation/wordpress-version/version-3-5/), Multisite users may use all of the functionality listed below. If you are running a version of WordPress older than 3.5, please update before installing a Multisite WordPress install on a subdirectory.
+
+**Note to theme/plugin developers:** this will not separate your code from WordPress. Themes and plugins will still reside under `wp-content` folder.
+
+## Moving a Root install to its own directory
+
+Let's say you've installed WordPress at `example.com`. Now you have two different methods to move WordPress installations into subdirectory:
+
+1. Without change of SITE-URL (remains `example.com`)
+2. With change in SITE-URL (it will redirect to `example.com/subdirectory`)
+
+## Method I (Without URL change)
+
+1. After Installing WordPress in the root folder, move EVERYTHING from the root folder into subdirectory.
+
+### Apache (.htaccess)
+2. Create a `.htaccess` file in the root folder, and put this content inside (just change `example.com` and `my_subdir`):
+
+```
+<IfModule mod_rewrite.c>
+RewriteEngine on
+RewriteCond %{HTTP_HOST} ^(www.)?example.com$
+RewriteCond %{REQUEST_URI} !^/my_subdir/
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteRule ^(.*)$ /my_subdir/$1
+RewriteCond %{HTTP_HOST} ^(www.)?example.com$
+RewriteRule ^(/)?$ my_subdir/index.php [L] 
+</IfModule>
+```
+
+### nginx (server block)
+2. Add this to your nginx server block:
+
+```nginx
+location /my_subdir/ {
+    try_files $uri $uri/ /my_subdir/index.php?$args;
+}
+
+location ~ \.php$ {
+    fastcgi_split_path_info ^(.+\.php)(/.*)$;
+    fastcgi_pass unix:/var/run/php/php8.3-fpm.sock;
+    fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+    include fastcgi_params;
+}
+```
+
+That's all 🙂
+
+## Method II (With URL change)
+
+### Moving process
+
+_(p.s. If you've already installed WP in subdirectory, some steps might be already done automatically)._
+
+1. Create the new location for the core WordPress files to be stored—we will use `/wordpress` in our examples. On Linux, use `mkdir wordpress` from your `www` directory. You'll probably want to use `chown apache:apache` on the `wordpress` directory you created.
+2. Go to the [General](https://wordpress.org/documentation/article/administration-screens/#settings-configuration-settings) screen.
+3. In **WordPress address (URL):** set the address of your main WordPress core files. Example: `https://example.com/wordpress`.
+4. In **Site address (URL):** set root directory's URL. Example: `https://example.com`.
+5. Click **Save Changes**. Do not worry about the errors that happen now! Continue reading.
+6. Now move your WordPress core files (from root directory) to the subdirectory.
+7. Copy (NOT MOVE!) the `index.php` and `.htaccess` files from the WordPress directory into the root directory of your site (Blog address). The `.htaccess` file is invisible, so you may have to set your FTP client to [show hidden files](https://developer.wordpress.org/advanced-administration/server/file-permissions/#Unhide_the_hidden_files). If you are not using [pretty permalinks](https://wordpress.org/documentation/article/using-permalinks/#using-pretty-permalinks), then you may not have a .`htaccess` file. _**If you are running WordPress on a Windows (IIS) server** and are using pretty permalinks, you'll have a `web.config` rather than a `.htaccess` file in your WordPress directory. For the `index.php` file the instructions remain the same, copy (don't move) the index.php file to your root directory. The `web.config` file, must be treated differently than the `.htaccess` file so you must MOVE (DON'T COPY) the `web.config` file to your root directory._
+8. Open your root directory's `index.php` file in a [text editor](https://wordpress.org/documentation/article/glossary#text-editor).
+9. Change the following and save the file. Change the line that says:`require dirname( __FILE__ ) . '/wp-blog-header.php';`to the following, using your directory name for the WordPress core files: `require dirname( __FILE__ ) . '/wordpress/wp-blog-header.php';`.
+10. Login to the new location. It might now be `https://example.com/wordpress/wp-admin/`.
+11. If you have set up [Permalinks](https://wordpress.org/documentation/article/using-permalinks/), go to the [Permalinks Screen](https://wordpress.org/documentation/article/administration-screens/#permalinks) and update your Permalink structure. WordPress will automatically update your `.htaccess` file if it has the appropriate file permissions. If WordPress can't write to your `.htaccess` file, it will display the new rewrite rules to you, which you should manually copy into your `.htaccess` file (in the same directory as the main `index.php` file).
+
+### .htaccess modification
+
+In some cases, some people like to install separate versions in a subdirectory (such as `/2010`, `/2011`, `/latest` and etc..), and want that website (by default) used the latest version, then Install WordPress in a subdirectory, such as `/my_subdir` and in your root folder's .htaccess file add the following (just change the words as you need):
+
+**Apache (.htaccess):**
+```
+RewriteEngine On
+RewriteCond %{HTTP_HOST} ^(www.)?example.com$
+RewriteRule ^(/)?$ my_subdir\[L\]
+```
+
+**nginx (server block):**
+```nginx
+location = / {
+    return 301 /my_subdir/;
+}
+
+location /my_subdir/ {
+    try_files $uri $uri/ /my_subdir/index.php?$args;
+}
+
+location ~ \.php$ {
+    fastcgi_split_path_info ^(.+\.php)(/.*)$;
+    fastcgi_pass unix:/var/run/php/php8.3-fpm.sock;
+    fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+    include fastcgi_params;
+}
+```
+
+Now when users to go your root domain (`example.com`), it will automatically redirect to the subdirectory you specified.
+
+Note: This code comes from Site 5's post here: [How to Redirect Your Domain to a Subfolder Using .htaccess](https://qa.site5.com/advanced/how-to-redirect-your-domain-to-a-subfolder-using-htaccess/).
+
+## Moving Specific WordPress Folders
+
+The following links explains how to change specific directories within WordPress:
+
+* [Moving wp-content folder](https://wordpress.org/documentation/article/editing-wp-config-php/#moving-wp-content-folder)
+* [Moving Plugin Folder](https://wordpress.org/documentation/article/editing-wp-config-php/#moving-plugin-folder)
+* [Moving Themes Folder](https://wordpress.org/documentation/article/editing-wp-config-php/#moving-themes-folder)
+* [Moving Uploads Folder](https://wordpress.org/documentation/article/editing-wp-config-php/#moving-uploads-folder)
+
+## See also
+
+* [Using Caddy to give WordPress its own directory](https://caddy.community/t/using-caddy-to-give-wordpress-its-own-directory/13185)
+

--- a/upgrade/migrating.md
+++ b/upgrade/migrating.md
@@ -1,0 +1,498 @@
+# Migrating WordPress
+
+## Changing The Site URL
+
+On the `Settings -> General` screen in a single site installation of WordPress, there are two fields named "WordPress Address (URL)" and "Site Address (URL)". They are important settings since they control where WordPress is located. These settings control the display of the URL in the admin section of your page, as well as the front end, and are used throughout the WordPress code.
+
+- The "Site Address (URL)" setting is the address you want people to type in their browser to reach your WordPress blog.
+- The "WordPress Address (URL)" setting is the address where your WordPress core files reside.
+
+**Note:** Both settings should include the https:// part and should not have a slash `/` at the end.
+
+Every once in a while, somebody finds a need to manually change (or fix) these settings. Usually, this happens when they change one or both and discover that their site no longer works properly. This can leave the user with no easily discoverable way to correct the problem. This article tells you how to change these settings directly.
+
+Additional information is presented here for the case where you are moving WordPress from one site to another, as this will also require changing the site URL. You should not attempt to use this additional information if you're only attempting to correct a "broken" site.
+
+**Alert!** These directions are for single installs of WordPress only. If you are using WordPress MultiSite, you will need to manually edit your database.
+
+There are four easy methods to change the Site URL manually. Any of these methods will work and perform much the same function.
+
+#### Edit wp-config.php
+
+It is possible to set the site URL manually in the `wp-config.php` file.
+
+Add these two lines to your `wp-config.php`, where "example.com" is the correct location of your site.
+
+```
+define( 'WP_HOME', 'https://example.com' );
+define( 'WP_SITEURL', 'https://example.com' );
+```
+
+This is not necessarily the best fix, it's just hard-coding the values into the site itself. You won't be able to edit them on the General settings page anymore when using this method.
+
+#### Edit functions.php
+
+If you have access to the site via FTP, then this method will help you quickly get a site back up and running, if you changed those values incorrectly.
+
+1. FTP to the site, and get a copy of the active theme's functions.php file. You're going to edit it in a simple text editor and upload it back to the site.
+2. Add these two lines to the file, immediately after the initial `<?php` line:
+
+```
+update_option( 'siteurl', 'https://example.com' );
+update_option( 'home', 'https://example.com' );
+``` 
+Obviously, use your own URL instead of `example.com`.
+
+3. Upload the file back to your site, in the same location. FileZilla offers a handy "edit file" function to do all of the above rapidly; if you can use that, do so.
+4. Load the login or admin page a couple of times. The site should come back up.
+
+**Important!** Do not leave this code in the `functions.php` file. Remove them after the site is up and running again.
+
+Note: If your theme doesn't have a `functions.php` file create a new one with a text editor. Add the `<?php` tag and the two lines using your own URL instead of `example.com`:
+
+```	
+<?php
+update_option( 'siteurl', 'https://example.com' );
+update_option( 'home', 'https://example.com' );
+```
+
+Upload this file to your theme directory. Remove the lines or remove the file after the site is up and running again.
+
+#### LAN-based site to externally accessible site
+
+Here are some additional details that step you through transferring a LAN-based WordPress site into an externally accessible site, as well as enabling editing the wordpress site from inside the LAN.
+
+Two important keys are router/firewall modifications and the "wait 10+ minutes" after making the changes at the end.
+
+1. Using SSH to log into your server (nano is a server preinstalled text editor):
+
+`$ nano /var/www/books/wp-content/themes/twentyeleven/functions.php`
+
+2. Add lines just after `<?php`
+
+```
+update_option( 'siteurl', 'https://example.com:port/yourblog');
+update_option( 'home', 'https://example.com:port/yourblog');
+```
+
+3. Refresh your web browser using your external site URL:
+
+https://example.com:port/yourblog
+`$ nano /var/www/books/wp-content/themes/twentyeleven/functions.php`
+
+4. Remove those lines you just added (or comment them out)
+
+5. Access your router, these steps are for pfSense, other routers should have similar settings to look for/watch out for)
+
+6. Add to firewall/nat table a line like this
+
+`wan/tcp/port/LAN.server.IP/80`
+
+7. Add to firewall/rules table a line like this:
+
+`tcp/*/port/LAN.server.IP/port/*`
+
+8. Uncheck the box at System/advanced/network address translation/Disable NAT Reflection
+
+`"Disables the automatic creation of NAT redirect rules for access to your public IP addresses from within your internal networks. Note: Reflection only works on port forward type items and does not work for large ranges > 500 ports."`
+
+9. Then go do something for ten minutes and when you get back see if the external url https://example.com:port/yourblog from a LAN browser brings the page up correctly. 
+
+#### Relocate method
+
+WordPress supports an automatic relocation method intended to be a quick assist to getting a site working when relocating a site from one server to another.
+
+#### Code function
+
+When RELOCATE has been defined as true in `wp-config.php` (see next chapter), the following code in `wp-login.php` will take action:
+
+```
+if ( defined( 'RELOCATE' ) AND RELOCATE ) {    
+	// Move flag is set
+	if ( isset( $_SERVER['PATH_INFO'] ) AND ($_SERVER['PATH_INFO'] != $_SERVER['PHP_SELF']) ) 
+		$_SERVER['PHP_SELF'] = str_replace( $_SERVER['PATH_INFO'], "", $_SERVER['PHP_SELF'] );
+	$url = dirname( set_url_scheme( 'https://'. $_SERVER['HTTP_HOST'] . $_SERVER['PHP_SELF'] ) );
+	if ( $url != get_option( 'siteurl' ) )
+		update_option( 'siteurl', $url );
+}
+```
+
+**Steps**
+
+1. Edit the `wp-config.php` file.
+2. After the "define" statements (just before the comment line that says "That's all, stop editing!"), insert a new line, and type: `define('RELOCATE',true);`
+3. Save your `wp-config.php` file.
+4. Open a web browser and manually point it to `wp-login.php` on the new server. For example, if your new site is at https://www.example.com, then type https://www.example.com/wp-login.php into your browser's address bar.
+5. Login as per normal.
+6. Look in your web browser's address bar to verify that you have, indeed, logged in to the correct server. If this is the case, then in the Admin back-end, navigate to `Settings > General` and verify that both the address settings are correct. Remember to Save Changes.
+7. Once this has been fixed, edit `wp-config.php` and either completely remove the line that you added (delete the whole line), comment it out (with `//`) or change the true value to false if you think it's likely you will be relocating again.
+
+**Note:** When the `RELOCATE` flag is set to true, the Site URL will be automatically updated to whatever path you are using to access the login screen. This will get the admin section up and running on the new URL, but it will not correct any other part of the setup. You'll still need to alter those manually. 
+
+**Important!** Leaving the RELOCATE constant in your `wp-config.php` file is insecure, as it allows an attacker to change your site URL to anything they want in some configurations. Always remove the RELOCATE line from `wp-config.php` after you're done. 
+
+#### Changing the URL directly in the database
+
+If you know how to access phpMyAdmin on your host, then you can edit these values directly to get your site up and running again.
+
+1. [Backup your database](https://developer.wordpress.org/advanced-administration/security/backup/database/) and save the copy off-site.
+2. Login to [phpMyAdmin](https://developer.wordpress.org/advanced-administration/upgrade/phpmyadmin/).
+3. Click the link to your **Databases**.
+4. A list of your databases will appear. Choose the one that is your WordPress database.
+5. All the tables in your database will appear on the screen.
+6. From the list, look for `wp_options`. **Note:** The table prefix of `wp_` may be different if you changed it when installing.
+7. Click on the small icon indicated as **Browse**.
+8. A screen will open with a list of the fields within the wp_options table.
+9. Under the field option_name, scroll down and look for `siteurl`.
+10. Click the **Edit Field** icon which usually is found at the far left at the beginning of the row.
+11. The **Edit Field** window will appear.
+12. In the input box for option_value, carefully change the URL information to the new address.
+13. Verify this is correct and click **Go** to save the information.
+14. You should be returned to your `wp_options` table.
+15. Look for the home field in the table and click **Edit Field**. **Note:** There are several pages of tables inside `wp_options`. Look for the > symbol to page through them.
+16. In the input box for option_value, carefully change the URL information to the new address.
+17. Verify this is correct and click **Go** to save the information.
+
+### Moving Sites
+
+When moving sites from one location to another, it is sometimes necessary to manually modify data in the database to make the new site URL information to be recognized properly. Many tools exist to assist with this, and those should generally be used instead of manual modifications.
+
+This is presented here as information only. This data may not be complete or accurate.
+
+You should read the [Moving WordPress](https://developer.wordpress.org/advanced-administration/upgrade/migrating/) article first, if attempting to move WordPress from one system to another. 
+
+#### Altering Table Prefixes
+
+Like many WordPress administrators, you may be running several WordPress installations off of one database using various `wp-config.php` hacks. Many of these hacks involve dynamically setting table prefixes, and if you do end up altering your table prefix, you must update several entries within the `prefix_usermeta` table as well.
+
+As in the above section, remember that SQL changes are permanent and so you should back up your database first: 
+
+If you are changing table prefixes for a site, then remember to alter the table prefix in the usermeta tables as well. This will allow the new site to properly recognize user permissions from the old site. 
+```
+UPDATE `newprefix_usermeta` SET `meta_key` = REPLACE( `meta_key` , 'oldprefix_', 'newprefix_' );
+```
+
+#### Changing Template Files
+
+In your WordPress Theme, open each template file and search for any manually entered references to your old domain name and replace it with the new one. Look for specific hand-coded links you may have entered on the various template files such as the `sidebar.php` and `footer.php`. WordPress uses a template tag called `bloginfo()` to automatically generate your site address from information entered in your Administration > Settings > General panel. The tag in your template files will not have to be modified. 
+
+#### Changing the Config file
+
+You will need to update your WordPress configuration file if your database has moved or changed in certain ways.
+
+1. You will only need to modify the config file if:
+  - your database has moved to another server and is not running on your localhost
+  - you have renamed your database
+  - you have changed the database user name
+2. Make a backup copy of your `wp-config.php` file.
+3. Open the `wp-config.php` file in a [text editor](https://wordpress.org/documentation/article/wordpress-glossary/#Text_editor).
+4. Review its contents. In particular, you are looking for the [database host entry](https://developer.wordpress.org/advanced-administration/wordpress/wp-config/#set-database-host).
+5. Save the file.
+6. At this point, your WordPress blog should be working.  
+
+#### Verify the Profile
+
+1. In your [Administration](https://wordpress.org/documentation/article/administration-screens/) > [Settings](https://wordpress.org/documentation/article/administration-screens/#general) > [General](https://wordpress.org/documentation/article/settings-general-screen/) panel, you will verify that the changes you made in Changing the URL above, are correct.
+2. Verify that the reference in your **WordPress Address (URL)** contains the new address.
+3. Verify that the reference in your **Site Address (URL)** contains the new address.
+4. If you have made changes, click **Save Changes**.
+
+#### Changing the .htaccess file
+
+After changing the information in your Administration > Settings > General panel, you will need to update your .htaccess file if you are using Permalinks or any rewrites or redirects. 
+
+1. **Make a backup copy** of your `.htaccess` file. This is not a recommendation but a requirement.
+2. Open the `.htaccess` file in a [text editor](https://wordpress.org/documentation/article/glossary/#text-editor).
+3. Review its contents, looking for any custom rewrites or redirects you entered. **Copy** these to another text file for safe keeping.
+4. Close the file.
+5. Follow the instructions on the Permalinks SubPanel for updating your Permalinks to the `.htaccess` file.
+6. Open the new `.htaccess` file and check to see if your custom rewrites and redirects are still there. If not, copy them from the saved file and paste them into the new `.htaccess` file.
+7. Make any changes necessary in those custom rewrites and redirects to reflect the new site address.
+8. Save the file.
+9. Test those redirects to ensure they are working.
+
+If you make a mistake, you can [Restore Your Database](https://developer.wordpress.org/advanced-administration/security/backup/) from your backup and try this again. So make sure it is right the first time.
+
+#### Additional items of note
+
+There are other things you may wish to change in order to correct URLs when moving sites.
+
+1. Images link: image links are stored in "post_content" in the `wp_posts` table. You can use the similar code above to update image links.
+2. wp_options: Besides the "siteurl" and "home" items mentioned above, there are other option_value that also need revision, such as "upload path", and some plugin items (depends on what you've installed, such as widgets, stats, DMSGuestbook, sitemap, etc.)
+3. To fix widgets that contain outdated URL's, you may edit them in Dashboard / Appearance / Widgets.
+4. Do a FULL database search for any items left. **MAKE SURE** you know what you are changing and go through each item for possible improper replacement.
+5. If you a running a network / have multiple sites, you will need to replace instances of the URL in the database. They are stored in many tables, including each one of the sites (blogs). Be careful in what you replace and be sure you know the meaning of the field before changing it. See the Important GUID note below for an example of what not to change.
+6. **Note:** If you find your old URL in the database options table under `dashboard_incoming_links`, you can ignore or delete that option. It's unused since WP 3.8.
+
+#### Important GUID Note
+
+When doing the above and changing the URLs directly in the database, you will come across instances of the URL being located in the "guid" column in the `wp_posts` tables. It is critical that you do NOT change the contents of this field.   
+
+The term "GUID" stands for "Globally Unique Identifier". It is a field that is intended to hold an identifier for the post which a) is unique across the whole of space and time and b) never, ever changes. The GUID field is primarily used to create the WordPress feeds. 
+
+When a feed-reader is reading feeds, it uses the contents of the GUID field to know whether or not it has displayed a particular item before. It does this in one of various ways, but the most common method is simply to store a list of GUID's that it has already displayed and "marked as read" or similar. 
+
+Thus, changing the GUID will mean that many feedreaders will suddenly display your content in the user's reader again as if it was new content, possibly annoying your users. 
+
+In order for the GUID field to be "globally" unique, it is an accepted convention that the URL or some representation of the URL is used. Thus, if you own `example.com`, then you're the only one using `example.com` and thus it's unique to you and your site. This is why WordPress uses the permalink, or some form thereof, for the GUID. 
+
+However, the second part of that is that the GUID must _never_ change. Even if you shift domains around, the post is still the same post, even in a new location. Feed readers being shifted to your new feeds when you change URLs should still know that they've read some of your posts before, and thus the GUID _must_ remain unchanged. 
+
+**Never, ever, change the contents of the GUID column, under any circumstances.**
+
+If the default uploads folder needs to be changed to a different location, then any media URLs will need to be changed in the `post_content` column of the posts table. For example, if the default uploads folder is changing from `wp-content/uploads` to `images`: 
+
+`UPDATE wp_posts SET post_content = REPLACE(post_content,'www.domain.com/wp-content/uploads','www.domain.com/images');`
+
+#### Multi-site notes
+
+See [Moving WordPress Multisite](https://developer.wordpress.org/advanced-administration/upgrade/migrating/#moving-wordpress-multisite)
+
+#### wp-cli
+
+[wp-cli](https://wp-cli.org/) is a super useful shell tool.
+
+`wp search-replace 'example.dev' 'example.com' --skip-columns=guid`
+
+Or, if you only want to change the option, you can do:
+```
+wp option update home 'https://example.com'
+wp option update siteurl 'https://example.com'
+```
+
+# Moving WordPress
+
+Whether you are moving WordPress to a new server or to a different location on your server, you don't need to reinstall. WordPress is flexible enough to handle all of these situations.
+
+## Moving to a New Server
+
+If you are moving WordPress from one server to another, begin by backing up your WordPress directory, images, plugins, and other files on your site as well as the database. See [WordPress Backups](https://developer.wordpress.org/advanced-administration/security/backup/) and [Backing Up Your Database](https://developer.wordpress.org/advanced-administration/security/backup/database/).
+
+### Keeping Your Domain Name and URLs
+
+Moving your domain without changing the Home and Site URLs of your WordPress site is very simple, and in most cases can be done by moving the files.
+
+- If database and URL remain the same, you can move by just copying your files and database.
+- If database name or user changes, [edit wp-config.php](https://developer.wordpress.org/advanced-administration/wordpress/wp-config/) to have the correct values.
+- If you want to test before you switch, you must temporarily change "siteurl" and "home" in the database table "wp_options" (through phpMyAdmin or similar).
+- If you had any kind of rewrites (permalinks) setup you must disable .htaccess and reconfigure permalinks when it goes live.
+
+### Changing Your Domain Name and URLs
+
+Moving a website and changing your domain name or URLs (i.e. from https://example.com/site to https://example.com, or https://example.com to https://example.net) requires the following steps – in sequence.
+
+1. Download your existing site files.
+2. Export your database – go in to MySQL and export the database.
+3. Move the backed up files and database into a new folder – somewhere safe – this is your site backup.
+4. Log in to the site you want to move and go to Settings > General, then change the URLs. (ie from https://example.com/ to https://example.net) – save the settings and expect to see a 404 page.
+5. Download your site files again.
+6. Export the database again.
+7. Edit `wp-config.php` with the new server's MySQL database name, user and password.
+8. Upload the files.
+9. Import the database on the new server.
+
+When your domain name or URLs change there are additional concerns. The files and database can be moved, however references to the old domain name or location will remain in the database, and that can cause issues with links or theme display.
+
+If you do a search and replace on your entire database to change the URLs, you can cause issues with data serialization, due to the fact that some themes and widgets store values with the length of your URL marked. When this changes, things break. To avoid that serialization issue, you have three options:
+
+1. Use the [Velvet Blues Update URLs](https://wordpress.org/plugins/velvet-blues-update-urls/) or [Better Search Replace](https://wordpress.org/plugins/better-search-replace/) plugins if you can access your Dashboard.
+2. Use [WP-CLI's search-replace](https://developer.wordpress.org/cli/commands/search-replace/) if your hosting provider (or you) have installed WP-CLI.
+3. Use the [Search and Replace for WordPress Databases Script](https://interconnectit.com/products/search-and-replace-for-wordpress-databases/) to safely change all instances on your old domain or path to your new one. (**only use this option if you are comfortable with database administration** )
+
+Note: Only perform a search and replace on the wp_posts table.
+Note: Search and Replace from Interconnectit is a 3rd party script
+
+## Moving Directories On Your Existing Server
+
+Moving the WordPress files from one location on your server to another – i.e. changing its URL – requires some special care. If you want to move WordPress to its own folder, but have it run from the root of your domain, please read Giving WordPress Its Own Directory for detailed instructions.
+
+Here are the step-by-step instructions to move your WordPress site to a new location on the same server:
+
+1. Create the new location using one of these two options:
+   - If you will be moving your WordPress core files to a new directory, create the new directory.
+   - If you want to move WordPress to your root directory, make sure all `index.php`, [.htaccess](https://wordpress.org/documentation/article/glossary/#htaccess), and other files that might be copied over are backed up and/or moved, and that the root directory is ready for the new WordPress files.
+2. Log in to your site.
+3. Go to the [Administration](https://wordpress.org/documentation/article/administration-screens/) > [Settings](https://wordpress.org/documentation/article/administration-screens/#settings-configuration-settings) > [General](https://wordpress.org/documentation/article/settings-general-screen/) screen.
+4. In the box for **WordPress Address (URL)**: change the address to the new location of your main WordPress core files.
+5. In the box for **Site Address (URL)**: change the address to the new location, which should match the WordPress (your public site) address.
+6. Click **Save Changes**.
+7. (Do not try to open/view your site now!)
+8. Move your WordPress core files to the new location. This includes the files found within the original directory, such as https://example.com/wordpress, and all the sub-directories, to the new location.
+9. Now, try to open your site by going to yourdomain.com/wp-admin. Note, you may need to go to yourdomain.com/wp-login.php
+10. If you are using [Permalinks](https://wordpress.org/documentation/article/using-permalinks/), go to the Administration > Settings > [Permalinks](https://wordpress.org/documentation/article/settings-permalinks-screen/) panel and update your Permalink structure to your [.htaccess](https://wordpress.org/documentation/article/glossary/#htaccess), file, which should be in the same directory as the main `index.php` file.
+11. Existing image/media links uploaded media will refer to the old folder and must be updated with the new location. You can do this with the [Better Search Replace](https://wordpress.org/plugins/better-search-replace/) or [Velvet Blues Update URLs](https://wordpress.org/plugins/velvet-blues-update-urls/) plugins, [WP-CLI's search-replace](https://developer.wordpress.org/cli/commands/search-replace/) if your hosting provider (or you) have installed WP-CLI, manually in your SQL database, or by using the 3rd party database updating tool [Search and Replace Databases Script](https://interconnectit.com/products/search-and-replace-for-wordpress-databases/) * **Note:** this script is best used by experienced developers.
+12. In some cases your permissions may have changed, depending on your ISP. Watch for any files with "0000" permissions and change them back to "0644".
+13. If your theme supports menus, links to your home page may still have the old subdirectory embedded in them. Go to Appearance > Menus and update them.
+14. Sometimes you would need to restart your server, otherwise your server may give out an error. (happens in MAMP software (Mac)).
+15. It is important that you set the URI locations BEFORE you move the files.
+
+#### If You Forget to Change the Locations
+
+If you accidentally moved the files before you changed the URIs: you have two options.
+
+1. Suppose the files were originally in /path/to/old/ and you moved them to /path/to/new before changing the URIs. The way to fix this would be to make 
+```
+/path/to/old/ a symlink (for Windows users, "symlink" is equivalent to "shortcut") to /path/to/new/, i.e.
+ln -s /path/to/new /path/to/old
+```
+and then follow the steps above as normal. Afterwards, delete the symlink if you want.
+
+2. If you forget to change the WordPress Address and Blog Address, you will be unable to change it using the WordPress interface. However, you can fix it if you have access to the database. Go to the database of your site and find the wp_options table. This table stores all the options that you can set in the interface. The WordPress Address and Blog Address are stored as `siteurl` and `home` (the option_name field). All you have to do is change the option_value field to the correct URL for the records with `option_name='siteurl‘` or `option_name='home‘`.
+
+Note: Sometimes, the WordPress Address and Blog Address are stored in [WordPress Transients](https://developer.wordpress.org/apis/handbook/transients/). Search and replace scripts can have trouble modifying those to the new address and some plugins might therefore refer to the old address because of them. Transients are temporary (cached) values stored in the wp_options database table that can be recreated on-demand when removed. It's therefore safe to delete them from the migrated database copy and let them be recreated. This database query (again, have a backup!) clears all transients:
+
+```
+DELETE FROM `wp_options` WHERE option_name LIKE '%\_transient\_%' 
+```
+
+#### If You Have Accidentally Changed your WordPress Site URL
+
+Suppose you accidentally changed the URIs where you cannot move the files (but can still access the login page, through a redirection or something).
+
+`wp-login.php` can be used to (re-)set the URIs. Find this line:
+
+```
+require( dirname(__FILE__) . '/wp-load.php' );
+```
+
+and insert the following lines below:
+
+```
+//FIXME: do comment/remove these hack lines. (once the database is updated)
+update_option('siteurl', 'https://example.com/the/path' );
+update_option('home', 'https://example.com/the/path' );
+```
+
+You're done. Test your site to make sure that it works right. If the change involves a new address for your site, make sure you let people know the new address, and consider adding some redirection instructions in your `.htaccess` file to guide visitors to the new location.
+
+[Changing The Site URL](https://developer.wordpress.org/advanced-administration/upgrade/migrating/) also provides the details of this process.
+
+
+## Managing Your Old Site
+
+### Shutting It Down
+1. Download a copy of the main WordPress files from your OLD site to your hard drive and [edit wp-config.php](https://developer.wordpress.org/advanced-administration/wordpress/wp-config/) to suit the new server.
+2. Go back to your OLD site and go to [Administration](https://wordpress.org/documentation/article/administration-screens/) > [Settings](https://wordpress.org/documentation/article/administration-screens/#settings-configuration-settings) > [General](https://wordpress.org/documentation/article/settings-general-screen/) screen and change the URL (both of them) to that of your new site.
+3. Login on your server, go to phpMyAdmin, export as file, and save your database (but keep the old one just in case). Now, upload this new database and the copy of the wordpress core files with the edited wp-config.php to your new server. That's it!
+
+#### Keeping it Running
+Caution: Make sure you have a backup of your old site's WordPress database before proceeding!
+
+_Part A – Activating Your New Site_
+
+1. Download your entire WordPress installation to your hard drive. Name the folder appropriately to indicate that this is your OLD site's installation.
+2. Download your database.
+3. Go back to your OLD site and go to options and change the url (both of them) to that of your new site.
+4. Again, download your entire WordPress installation to your hard drive. Name the folder appropriately to indicate that this is your NEW site's installation.
+5. Download your database once again (but keep the old one). Upload this database to your new server. It will be easiest if you use the same database name and you create a user with the same login credentials on your new server as on your old server.
+6. If you used a different database name and/or user (see previous step), [edit wp-config.php](https://developer.wordpress.org/advanced-administration/wordpress/wp-config/) in your NEW site's installation folder appropriately.
+7. Upload the NEW site's installation folder to your new site. Presto, your NEW site should be working!
+
+_Part B – Restoring Your Old Site_
+
+1. On the original server, delete your OLD site's database (remember, you should have a copy on your local computer that you made at the very beginning).
+2. Upload your OLD site's installation folder to your original server, overwriting the files that are currently there (you may also delete the installation folder on the server and simply re-upload the OLD site's files).
+3. Upload your OLD site's database from your local computer to the server. That should do it!
+
+Another procedure for making copies of posts, comments, pages, categories and custom field (post status, data, permalinks, ping status, etc.) easy to follow:
+
+1. Install a new WordPress site
+2. Go to the old site Admin panel. Here, in Manage > Export select "all" in the menu Restrict Author.
+3. Click on Download Export File
+4. In the new site go to Manage > Import, and choose WordPress item.
+5. On the page that will be shown, select the file just exported. Click on Upload file and Import
+6. It will appear on a page. In Assign Authors, assign the author to users that already exist or create new ones.
+7. Click on Submit
+8. At the end, click on Have fun
+
+_Note: using this method, if there are some articles in the new site (like Hello World, Info Page, etc.), these will not be erased. Articles are only added. Using the former procedure, the articles in the new site will be deleted._
+
+## Moving WordPress Multisite
+
+[Multisite](https://developer.wordpress.org/advanced-administration/multisite/create-network/) is somewhat more complicated to move, as the database itself has multiple references to the server name as well as the folder locations. If you're simply moving to a new server with the same domain name, you can copy the files and database over, exactly as you would a traditional install.
+
+If, instead, you are changing domains, then the best way to move Multisite is to move the files, edit the `.htaccess` and `wp-config.php` (if the folder name containing Multisite changed), and then manually edit the database. Search for all instances of your domain name, and change them as needed. This step cannot yet be easily automated. It's safe to search/replace any of the `wp_x_posts` tables, however do not attempt blanket search/replace without the [Search and Replace for WordPress Databases](https://github.com/interconnectit/Search-Replace-DB) script (aka the interconnectit script).
+
+If you're moving Multisite from one folder to another, you will need to make sure you edit the `wp_blogs` entries to change the folder name correctly. You should manually review both `wp_site` and `wp_blogs` regardless, to ensure all sites were changed correctly.
+
+Also, manually review all the wp_x_options tables look for three fields, and edit them as needed:
+
+- home
+- siteurl
+- fileupload_url
+
+If you are moving from subdomains to subfolders, or vice-versa, remember to adjust the .htaccess file and the value for SUBDOMAIN_INSTALL in your `wp-config.php` file accordingly.
+
+### Related Links
+
+- [Moving a blog from wordpress.com to self-hosted blog](https://problogger.com/how-to-move-from-wordpresscom-to-wordpressorg/)
+- [Moving WordPress to a new domain or server](https://sltaylor.co.uk/blog/moving-wordpress-new-domain-server/)
+- [Italian version of this article – Versione italiana dell'articolo](https://www.valent-blog.eu/2007/09/14/trasferire-wordpress/)
+- [Search and Replace for WordPress Databases](https://interconnectit.com/search-and-replace-for-wordpress-databases/)
+- [PHP script to replace site url in WordPress database dump, even with WPML](http://blog.lavoie.sl/2012/07/php-script-to-replace-site-url-in.html)
+- [The Duplicator plugin helps administrators move a site from one location to another](https://wordpress.org/plugins/duplicator/)
+- [Technical tutorial on moving your WordPress blog to Bitnami's AWS configuration](https://agileweboperations.com/2011/01/20/migrate-your-wordpress-blog-to-a-bitnami-ec2-instance/)
+
+# Migrating multiple blogs into WordPress multisite
+
+This tutorial explains how to migrate multiples WordPress installs to a WordPress multisite install. You can migrate sites that use their own domain names, as well as sites that use a subdomain on your primary domain.
+
+This tutorial assumes that you are hosting WordPress on a server using cPanel. If you are using another solution to manage your server, you'll have to adapt these instructions.
+
+### Steps to Follow
+
+#### Backup your site
+
+Generate a full site backup in cPanel. It might also help to copy all the files on the server via FTP, so that you can easily access the files for plugins and themes, which you'll need in a later step.
+
+#### Export from your existing WordPress installs
+In each of your existing WordPress installations, go to Tools > Export in WordPress. Download the WXR files that contain all your posts and pages for each site. See the instructions on the [Tools Export Screen](https://wordpress.org/documentation/article/tools-export-screen/).
+
+Make sure that your export file actually has all the posts and pages. You can verify this by looking at the last entry of the exported file using a text editor. The last entry should be the most recent post.
+
+Some plugins can conflict with the export process, generating an empty file, or a partially complete file. To be on the safe side, you should probably disable all plugins before doing the exports.
+
+It's also a good idea to first delete all quarantined spam comments as these will also be exported, making the file unnecessarily large.
+
+**Note:** Widget configuration and blog/plugin settings are NOT exported in this method. If you are migrating within a single hosting account, make note of those settings at this stage, because when you delete the old domain, they will disappear.
+
+#### Install WordPress
+Install WordPress. Follow the instructions for [Installing WordPress](https://developer.wordpress.org/advanced-administration/before-install/howto-install/).
+
+#### Activate multisite
+Activate multi-site in your WordPress install. This involves editing `wp-config.php` a couple of times. You need to use the subdomain, not the subdirectory, option. See the instructions on how to [Create A Network](https://developer.wordpress.org/advanced-administration/multisite/create-network/).
+
+#### Create blogs for each site you want to import
+Create blogs for each of the sites you want to host in separate domains. For example, `importedblogdotorg.mydomain.com`.
+
+Note: choose the name carefully, because changing it causes admin redirection issues. This is particularly important if you are migrating a site within the same hosting account.
+
+#### Import WXR files for each blog
+Go to the backend of each blog, and import the exported WXR file for each blog. Map the authors to the proper users, or create new ones. Be sure to check the box that will pull in photos and other attachments. See the instructions on Tools Import SubPanel.
+
+**Note:** If you choose to import images from the source site into the target site, make sure they have been uploaded into the right place and are displayed correctly in the respective post or page.
+
+#### Edit WordPress configuration settings for each site
+
+Edit the configuration settings, widget, etc. for each site. By the end of this step, each site should look exactly as it did before, only with the URL `subdomain.example.com` or `example.com/subsite` rather than its correct, final URL.
+
+#### Limitations of PHP configuration
+You may run into trouble with the PHP configuration on your host. There are two potential problems. One is that PHP's `max_upload_size` will be too small for the WXR file. The other problem is that the PHP memory limit might be too small for importing all the posts.
+
+There are a couple of ways to solve it. One is to ask your hosting provider to up the limits, even temporarily. The other is to put a php.ini file in your /wp-admin/ and /wp-includes directories that ups the limits for you (php.ini files are not recursive, so it has to be in those directories). Something like a 10 MB upload limit and a 128 MB memory limit should work, but check with your hosting provider first so that you don't violate the terms of your agreement.
+
+Search the [WordPress forum support](https://wordpress.org/support/forums/) for help with PHP configuration problems.
+
+#### Converting add-on domains to parked domains
+
+Deleting add-on domains in cPanel and replacing them with parked domains will also delete any domain forwarders and e-mail forwarders associated with those domains. Be aware of this, so that you can restore those forwarders once you've made the switch.
+
+#### Limitations of importing users
+
+As there is the above way to import the content into an instance of the Multisite-blog, you are running into massive troubles, when it gets to import multiple users. Users are generated during the import, but you won't get any roles or additional information into the new blog.
+
+#### Losing settings
+If the old site is no longer available and you find you have forgotten to copy some setting or you want to make sure you have configured everything correctly, run a google search for your site and then click to view the cached version. This option is available only until your new site has been crawled, so you'd better be quick.
+
+Another option might be the [Internet Archive Wayback Machine](https://archive.org/web/). They may have a copy of the site (or some part of it) archived.
+


### PR DESCRIPTION
## Purpose

There is no web server configuration content in this handbook today. No Nginx, no Apache, no `.htaccess`, no mail, no migration. This PR moves twelve pages from the [Advanced Administration Handbook](https://developer.wordpress.org/advanced-administration/) that fill that gap, unchanged.

The Hosting Team has been carrying that handbook without really maintaining it. Commits went 265 → 92 → 46 → 12 across 2023 to 2026. Four section index pages publish blank right now, and three finished pages have never been published at all because nobody added them to the hand-maintained manifest.

Moving all 75 pages across would be worse than leaving it alone. This handbook is 2,363 lines and that one is 10,370, so we would land at roughly 80% inherited content, most of it written for people who are not hosting companies: Post Formats, CSS, FileZilla, and 649 lines describing the default theme of WordPress 1.5. That moves the maintenance onto us without making it any smaller.

So the question is which parts we are the right owner for. This PR takes the twelve where the answer is obvious, where the reader is a platform engineer running WordPress for customers.

## This PR only moves files

Every file is byte-identical to its source and keeps its original path. No edits, no merges, no renames, no reformatting.

| file | lines | lives today at |
|---|---:|---|
| `server/index.md` | 44 | [`/server/`](https://developer.wordpress.org/advanced-administration/server/) |
| `server/nginx.md` | 695 | [`/server/web-server/nginx/`](https://developer.wordpress.org/advanced-administration/server/web-server/nginx/) |
| `server/httpd.md` | 363 | [`/server/web-server/httpd/`](https://developer.wordpress.org/advanced-administration/server/web-server/httpd/) |
| `server/file-permissions.md` | 310 | [`/server/file-permissions/`](https://developer.wordpress.org/advanced-administration/server/file-permissions/) |
| `server/wordpress-in-directory.md` | 119 | [`/server/wordpress-in-directory/`](https://developer.wordpress.org/advanced-administration/server/wordpress-in-directory/) |
| `server/mail.md` | 100 | [`/server/mail/`](https://developer.wordpress.org/advanced-administration/server/mail/) |
| `server/control-panel.md` | 83 | [`/server/control-panel/`](https://developer.wordpress.org/advanced-administration/server/control-panel/) |
| `server/subdomains-wildcard.md` | 57 | [`/server/subdomains-wildcard/`](https://developer.wordpress.org/advanced-administration/server/subdomains-wildcard/) |
| `multisite/index.md` | 10 | [`/multisite/`](https://developer.wordpress.org/advanced-administration/multisite/) |
| `multisite/create-network.md` | 113 | [`/multisite/create-network/`](https://developer.wordpress.org/advanced-administration/multisite/create-network/) |
| `security/hardening.md` | 387 | [`/security/hardening/`](https://developer.wordpress.org/advanced-administration/security/hardening/) |
| `upgrade/migrating.md` | 498 | [`/upgrade/migrating/`](https://developer.wordpress.org/advanced-administration/upgrade/migrating/) |

**2,779 lines across twelve added files. Nothing else in the repo changed.**

## Nothing publishes yet

`gen_hb_manifest()` runs `glob( HOSTING_HANDBOOK_PATH . '/*.md' )`, which is the repository root only, no recursion. Nothing under `server/`, `multisite/`, `security/` or `upgrade/` is visible to it, `bin/handbook-manifest.json` is untouched, and the handbook renders exactly as it does today.

I checked that rather than assuming it. Running `gen-all` against a throwaway copy of this branch produces the same sixteen root-page keys as before and none of the twelve.

That is why the move is split off on its own. These pages still carry 66 hardcoded `developer.wordpress.org/advanced-administration/` links. `multisite/create-network.md` has 19 of them and `server/index.md` is almost nothing but links, so publishing now would walk readers straight back to the handbook they just came from. Landing the files first makes the follow-up a readable diff against content that is already here.

## Nothing is removed from the Advanced Administration Handbook

All twelve URLs stay live and unchanged. Retiring them needs the redirects in place first, and there is a wrinkle there worth flagging early: a redirect layer already points *into* that handbook. 62 live entries from `/documentation/article/*`, set up when the Documentation Team moved technical content out of HelpHub in 2023. Those need repointing rather than chaining, and for the pages heading back to HelpHub they need deleting, or the URL redirects to itself. Who owns the developer.wordpress.org side of this is still an open question with `#meta`.

## Why these twelve and not the other eighteen

Thirty pages belong on the hosting side. Eighteen of them fold into pages we already have: `security/backup` and friends into `reliability.md`, `https` and `brute-force` into `security.md`, `optimization` into `performance.md`. That is editing rather than moving and it deserves its own review. `reliability.md` is a 15-line stub that names backups, monitoring and version control and then says almost nothing about any of them, and there are 572 lines waiting for it.

## Follow-ups, each its own PR

1. **Fix the generator** so it walks subdirectories and preserves curated `parent`, `order` and `title`. This is a prerequisite for publishing anything moved here. `gen-all` is destructive right now, dropping every `order` and resetting every `parent` to `null`.
2. **Wire the manifest and navigation.** Final slugs and section shape: `Server`, `Multisite`, `Migration`, `Security → Hardening`. Root `order` values 7–9 are unused and sit right at the seam.
3. **Rewrite the 66 internal links.**
4. **The eighteen merge pages.**
5. **Redirects**, once `#meta` confirms who owns them.
6. **`team-projects.md`**, which still lists the Advanced Administration Handbook as one of our three projects and points contributors at it.
7. **`server/control-panel.md`** pulls four images from `user-images.githubusercontent.com`. Those want re-hosting under `/assets/` and the media library.

## Review

Two hosting-team reviewers, per `CONTRIBUTING.md`. Thank you in advance for the read, it is a big diff for what it actually does.

The useful question here is not whether the prose is good, since it is unchanged upstream text and some of it needs work. It is whether these twelve are ours to maintain. If you think one of them is not, let me know and I will drop it from the set.
