### PR TITLE
Mark the WordPress 7.0 compatibility page as AI assisted

### DIFF
--- a/version/7-0-compatibility.md
+++ b/version/7-0-compatibility.md
@@ -139,3 +139,5 @@ For step-by-step upgrade paths from any older WordPress version, see [Upgrading 
 ---
 
 _Questions or corrections? Leave a comment below, or find us in the [#hosting channel](https://wordpress.slack.com/archives/hosting/) of the [WordPress Slack](https://make.wordpress.org/chat/)._
+
+_Page contents were AI assisted._


### PR DESCRIPTION
The 7.1 compatibility page carries a line saying its contents were AI assisted, added after @kittenkamala asked for it in review on #415. The 7.0 page was written the same way in the same batch of work, so it should say the same thing.

One line at the bottom of `version/7-0-compatibility.md`, matching the wording and placement on the 7.1 page.

Keeping it separate from #415 because that page is already merged, and this way the disclosure is not sitting behind a review of unrelated 7.1 content.
