### PR TITLE
Document the `hash` extension requirement

### DIFF
--- a/server-environment.md
+++ b/server-environment.md
@@ -372,6 +372,7 @@ The following extensions are part of PHP itself and are always enabled in suppor
 The PHP extensions listed below are _required_ for a WordPress site to work.
 
 - [json](https://www.php.net/manual/en/book.json.php) - Used for communications with other servers and processing data in JSON format. (Always enabled in PHP >= 8.0; enabled by default in PHP 7.x but can be disabled in custom builds.)
+- [hash](https://www.php.net/manual/en/book.hash.php) - Provides access to cryptographically secure algorithms for hashing functions.
 - [mysqli](https://www.php.net/manual/en/book.mysqli.php) - Connects to MySQL/MariaDB for database interactions. Many PHP builds use [mysqlnd](https://www.php.net/manual/en/book.mysqlnd.php) as the underlying driver, but `mysqlnd` is not a standalone replacement for `mysqli`.
 
 The PHP extensions listed below are _highly recommended_ in order to allow WordPress to operate optimally and to maximise compatibility with many popular plugins and themes.


### PR DESCRIPTION
The `hash` extension is required since WordPress 6.8.

Refs:

- https://core.trac.wordpress.org/ticket/62815
- https://make.wordpress.org/core/2025/02/17/wordpress-6-8-will-use-bcrypt-for-password-hashing/