### PR TITLE
Change "Github" to "GitHub" across the handbook

### DIFF
--- a/get-involved.md
+++ b/get-involved.md
@@ -16,7 +16,7 @@ The recommendations were put together by the team and used as a basis for [Site 
 
 ### Improvements in the development of the Automated Hosting Tests
 
-The handbook is in the process of being audited and improved. You can see the progress and contribute [through Github](https://github.com/WordPress/phpunit-test-runner).
+The handbook is in the process of being audited and improved. You can see the progress and contribute [through GitHub](https://github.com/WordPress/phpunit-test-runner).
 
 You can propose improvements or solve those available in both the [PHPUnit test runner (issues)](https://github.com/WordPress/phpunit-test-runner/issues) and the [PHPUnit test reporter (issues)](https://github.com/WordPress/phpunit-test-reporter/issues).
 
@@ -142,4 +142,4 @@ The following are ways that a volunteer currently can earn a hosting contributor
 
 If you've contributed and don't yet have a badge, apologies! [Visit the Hosting Contributor page and submit a request](https://profiles.wordpress.org/associations/hosting-contributor/) with details on your contribution. Please feel free to ping any of the Team Reps on Slack with questions.
 
-[info]If you’re interested in improving this handbook, check the [Github Handbook repo](https://github.com/WordPress/hosting-handbook/), or leave a message in the [#hosting channel](https://wordpress.slack.com/archives/hosting/) of the official [WordPress Slack](https://make.wordpress.org/chat/).[/info]
+[info]If you’re interested in improving this handbook, check the [GitHub Handbook repo](https://github.com/WordPress/hosting-handbook/), or leave a message in the [#hosting channel](https://wordpress.slack.com/archives/hosting/) of the official [WordPress Slack](https://make.wordpress.org/chat/).[/info]

--- a/index.md
+++ b/index.md
@@ -35,4 +35,4 @@ Everyone is welcome! This may include folks hosting WordPress, interested in lea
 
 The Hosting Team meets in the WordPress Slack, in the [#hosting](https://wordpress.slack.com/archives/hosting/) channel. The conversations are in English. Check out the [WordPress Meeting calendar](https://make.wordpress.org/meetings#hosting) for the current schedule.
 
-[info]If you’re interested in improving this handbook, check the [Github Handbook repo](https://github.com/WordPress/hosting-handbook/), or leave a message in the [#hosting channel](https://wordpress.slack.com/archives/hosting/) of the official [WordPress Slack](https://make.wordpress.org/chat/).[/info]
+[info]If you’re interested in improving this handbook, check the [GitHub Handbook repo](https://github.com/WordPress/hosting-handbook/), or leave a message in the [#hosting channel](https://wordpress.slack.com/archives/hosting/) of the official [WordPress Slack](https://make.wordpress.org/chat/).[/info]

--- a/security.md
+++ b/security.md
@@ -161,7 +161,7 @@ Memcached is a memory object caching solution commonly used to provide database 
 WordPress has the ability to automatically apply security updates. This should be enabled in almost all cases. The exception is if files are not writable, outside of `wp-content/uploads`, for security reasons. In this instance, an alternative, expedient, and, preferably, automatic update process should be made available. See [Configuring Automatic Background Updates  
 ](https://developer.wordpress.org/advanced-administration/upgrade/upgrading/#configuring-automatic-background-updates) for details on automatic update configuration.
 
-[info]If you’re interested in improving this handbook, check the [Github Handbook repo](https://github.com/WordPress/hosting-handbook/), or leave a message in the [#hosting channel](https://wordpress.slack.com/archives/hosting/) of the official [WordPress Slack](https://make.wordpress.org/chat/).[/info]
+[info]If you’re interested in improving this handbook, check the [GitHub Handbook repo](https://github.com/WordPress/hosting-handbook/), or leave a message in the [#hosting channel](https://wordpress.slack.com/archives/hosting/) of the official [WordPress Slack](https://make.wordpress.org/chat/).[/info]
 
 
 # Responsible Disclosure
@@ -170,4 +170,4 @@ Responsible disclosure means the following: if you encounter a security breach (
 
 To report a security issue, please visit the [WordPress HackerOne](https://hackerone.com/wordpress) program and file a ticket there.
 
-If you encounter security issues or insecure recommendations in the hosting documentation, we would like you to raise an issue in the [hosting-handbook Github repository](https://github.com/WordPress/hosting-handbook/issues/).
+If you encounter security issues or insecure recommendations in the hosting documentation, we would like you to raise an issue in the [hosting-handbook GitHub repository](https://github.com/WordPress/hosting-handbook/issues/).

--- a/server-environment.md
+++ b/server-environment.md
@@ -563,4 +563,4 @@ If you have WordPress 5.2+, the WordPress Admin already has tools with that info
 
 If you have an older version, you can activate the `Site Health` section installing the WordPress Community Plugin called [Health Check & Troubleshooting](https://wordpress.org/plugins/health-check/) (more [help for this plugin](https://make.wordpress.org/support/handbook/appendix/troubleshooting-using-the-health-check/)).
 
-[info]If you’re interested in improving this handbook, check the [Github Handbook repo](https://github.com/WordPress/hosting-handbook/), or leave a message in the [#hosting channel](https://wordpress.slack.com/archives/hosting/) of the official [WordPress Slack](https://make.wordpress.org/chat/).[/info]
+[info]If you’re interested in improving this handbook, check the [GitHub Handbook repo](https://github.com/WordPress/hosting-handbook/), or leave a message in the [#hosting channel](https://wordpress.slack.com/archives/hosting/) of the official [WordPress Slack](https://make.wordpress.org/chat/).[/info]

--- a/team-projects.md
+++ b/team-projects.md
@@ -25,7 +25,7 @@ _Those skills are not required, but help._
 
 ### How
 
-The handbook is in the process of being audited and improved. You can see the progress and contribute [through Github](https://github.com/WordPress/hosting-handbook).
+The handbook is in the process of being audited and improved. You can see the progress and contribute [through GitHub](https://github.com/WordPress/hosting-handbook).
 
 The first thing you'll have to do is [visit the repository page](https://github.com/WordPress/hosting-handbook) where all the information is. It's best to [visit the Issues list](https://github.com/WordPress/hosting-handbook/issues), check if your proposal is already contemplated or pending, and if it isn't, [create a New issue](https://github.com/WordPress/hosting-handbook/issues/new).
 

--- a/team-reps.md
+++ b/team-reps.md
@@ -139,7 +139,7 @@ A Project Lead is responsible for guiding and overseeing a specific project unde
   - [Hosting Tests Team](https://github.com/orgs/WordPress/teams/hosting-tests-team).
 
 - **GitHub Repos**
-  - [Hosting Handbook](https://github.com/WordPress/hosting-handbook) Github Repo
-  - [Advanced Admin Handbook](https://github.com/WordPress/Advanced-administration-handbook) Github Repo
-  - [WordPress PHPUnit test suite](https://github.com/WordPress/phpunit-test-runner) Github Repo (aka test-runner)
-  - [WordPress PHPUnit test reporter](https://github.com/WordPress/phpunit-test-reporter) Github Repo (aka test-reporter)
+  - [Hosting Handbook](https://github.com/WordPress/hosting-handbook) GitHub Repo
+  - [Advanced Admin Handbook](https://github.com/WordPress/Advanced-administration-handbook) GitHub Repo
+  - [WordPress PHPUnit test suite](https://github.com/WordPress/phpunit-test-runner) GitHub Repo (aka test-runner)
+  - [WordPress PHPUnit test reporter](https://github.com/WordPress/phpunit-test-reporter) GitHub Repo (aka test-reporter)

--- a/version/index.md
+++ b/version/index.md
@@ -4,4 +4,4 @@ Server compatibility details for each WordPress release. Each page under this on
 
 For the summary matrix across every release, see [WordPress Compatibility](https://make.wordpress.org/hosting/handbook/compatibility/). Announcements for each release are published under [Release Compatibility](https://make.wordpress.org/hosting/category/release-compatibility/) on the Hosting Team blog.
 
-[info]If you're interested in improving this handbook, check the [Github Handbook repo](https://github.com/WordPress/hosting-handbook/), or leave a message in the [#hosting channel](https://wordpress.slack.com/archives/hosting/) of the official [WordPress Slack](https://make.wordpress.org/chat/).[/info]
+[info]If you're interested in improving this handbook, check the [GitHub Handbook repo](https://github.com/WordPress/hosting-handbook/), or leave a message in the [#hosting channel](https://wordpress.slack.com/archives/hosting/) of the official [WordPress Slack](https://make.wordpress.org/chat/).[/info]


### PR DESCRIPTION
Fixes #412

The issue reports the Security page, where "Github" appears twice. A sweep of the repository found the same spelling in twelve places across seven files, mostly through the shared [info] footer that is reused on several pages, plus the team-reps list and two "through Github" links.

This corrects every display text occurrence to the official "GitHub" branding. URLs are unchanged.